### PR TITLE
ci(lint): use mise

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,40 +153,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      - name: Pip cache
-        id: cache
-        uses: actions/cache@v4
+      - name: Setup mise
+        uses: jdx/mise-action@v2
         with:
-          path: |
-            ~/.cache
-            ~/.nox
-          key: ${{ runner.os }}-nox-lint-${{ matrix.session.session }}-${{hashFiles('**/uv.lock') }} }}
-          restore-keys: |
-            ${{ runner.os }}-lint-nox-${{ matrix.session.session }}-
-            ${{ runner.os }}-lint-nox-
+          cache: true
+          log_level: debug
 
-      - name: Setup nox
-        id: setup-nox
-        uses: wntrblm/nox@main
-        with:
-          python-versions: "3.12"
-
-      - name: Setup uv
-        id: setup-uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-          cache-suffix: ${{ runner.os }}-${{ matrix.session.session }}
-
-      - name: Install dependencies
-        run: uv sync --group lint
-
-      - name: Add .venv/bin to PATH
-        run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
-
-      - run: nox -t lint
+      - name: Run linting
+        run: mise run lint
 
   # Ensure the workflow is successful only if all job in matrixes are successful
   result:

--- a/mise.toml
+++ b/mise.toml
@@ -66,7 +66,6 @@ description = "Lint the code"
 alias = "l"
 depends = ["vulture", "pyright", "ruff"]
 
-
 [tasks.auto-bump]
 description = "Auto bump the version"
 depends = "install"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ test = [
     "pytest-xdist",
     "syrupy"
 ]
-lint = ["pyright", "ruff", "vulture"]
+lint = ["pyright[nodejs]", "ruff", "vulture"]
 doc = ["git-cliff>=2.6.1"]
 
 [tool.bumpversion]

--- a/uv.lock
+++ b/uv.lock
@@ -444,6 +444,22 @@ wheels = [
 ]
 
 [[package]]
+name = "nodejs-wheel-binaries"
+version = "22.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/c7/4fd3871d2b7fd5122216245e273201ab98eda92bbd6fe9ad04846b758c56/nodejs_wheel_binaries-22.14.0.tar.gz", hash = "sha256:c1dc43713598c7310d53795c764beead861b8c5021fe4b1366cb912ce1a4c8bf", size = 8055 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/b6/66ef4ef75ea7389ea788f2d5505bf9a8e5c3806d56c7a90cf46a6942f1cf/nodejs_wheel_binaries-22.14.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:d8ab8690516a3e98458041286e3f0d6458de176d15c14f205c3ea2972131420d", size = 50326597 },
+    { url = "https://files.pythonhosted.org/packages/7d/78/023d91a293ba73572a643bc89d11620d189f35f205a309dd8296aa45e69a/nodejs_wheel_binaries-22.14.0-py2.py3-none-macosx_11_0_x86_64.whl", hash = "sha256:b2f200f23b3610bdbee01cf136279e005ffdf8ee74557aa46c0940a7867956f6", size = 51158258 },
+    { url = "https://files.pythonhosted.org/packages/af/86/324f6342c79e5034a13319b02ba9ed1f4ac8813af567d223c9a9e56cd338/nodejs_wheel_binaries-22.14.0-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0877832abd7a9c75c8c5caafa37f986c9341ee025043c2771213d70c4c1defa", size = 57180264 },
+    { url = "https://files.pythonhosted.org/packages/6d/9f/42bdaab26137e31732bff00147b9aca2185d475b5752b57a443e6c7ba93f/nodejs_wheel_binaries-22.14.0-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8fded5a70a8a55c2135e67bd580d8b7f2e94fcbafcc679b6a2d5b92f88373d69", size = 57693251 },
+    { url = "https://files.pythonhosted.org/packages/ab/d7/94f8f269aa86cf35f9ed2b70d09aca48dc971fb5656fdc4a3b69364b189f/nodejs_wheel_binaries-22.14.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c1ade6f3ece458b40c02e89c91d5103792a9f18aaad5026da533eb0dcb87090e", size = 58841717 },
+    { url = "https://files.pythonhosted.org/packages/2d/a0/43b7316eaf22b4ee9bfb897ee36c724efceac7b89d7d1bedca28057b7be1/nodejs_wheel_binaries-22.14.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:34fa5ed4cf3f65cbfbe9b45c407ffc2fc7d97a06cd8993e6162191ff81f29f48", size = 59808791 },
+    { url = "https://files.pythonhosted.org/packages/10/0a/814491f751a25136e37de68a2728c9a9e3c1d20494aba5ff3c230d5f9c2d/nodejs_wheel_binaries-22.14.0-py2.py3-none-win_amd64.whl", hash = "sha256:ca7023276327455988b81390fa6bbfa5191c1da7fc45bc57c7abc281ba9967e9", size = 40478921 },
+    { url = "https://files.pythonhosted.org/packages/f4/5c/cab444afaa387dceac8debb817b52fd00596efcd2d54506c27311c6fe6a8/nodejs_wheel_binaries-22.14.0-py2.py3-none-win_arm64.whl", hash = "sha256:fd59c8e9a202221e316febe1624a1ae3b42775b7fb27737bf12ec79565983eaf", size = 36206637 },
+]
+
+[[package]]
 name = "nox"
 version = "2025.2.9"
 source = { registry = "https://pypi.org/simple" }
@@ -771,6 +787,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d6/4c/50c74e3d589517a9712a61a26143b587dba6285434a17aebf2ce6b82d2c3/pyright-1.1.394-py3-none-any.whl", hash = "sha256:5f74cce0a795a295fb768759bbeeec62561215dea657edcaab48a932b031ddbb", size = 5679540 },
 ]
 
+[package.optional-dependencies]
+nodejs = [
+    { name = "nodejs-wheel-binaries" },
+]
+
 [[package]]
 name = "pytest"
 version = "8.3.4"
@@ -1078,7 +1099,7 @@ dev = [
     { name = "bump-my-version" },
     { name = "git-cliff" },
     { name = "nox", extra = ["uv"] },
-    { name = "pyright" },
+    { name = "pyright", extra = ["nodejs"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1092,7 +1113,7 @@ doc = [
     { name = "git-cliff" },
 ]
 lint = [
-    { name = "pyright" },
+    { name = "pyright", extra = ["nodejs"] },
     { name = "ruff" },
     { name = "vulture" },
 ]
@@ -1127,7 +1148,7 @@ dev = [
     { name = "git-cliff" },
     { name = "git-cliff", specifier = ">=2.6.1" },
     { name = "nox", extras = ["uv"] },
-    { name = "pyright" },
+    { name = "pyright", extras = ["nodejs"] },
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "pytest-cov" },
@@ -1139,7 +1160,7 @@ dev = [
 ]
 doc = [{ name = "git-cliff", specifier = ">=2.6.1" }]
 lint = [
-    { name = "pyright" },
+    { name = "pyright", extras = ["nodejs"] },
     { name = "ruff" },
     { name = "vulture" },
 ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

-

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Updates the linting workflow to use mise for managing linters and their versions, replacing the previous nox-based setup. This simplifies the CI configuration and improves dependency management.

CI:
- Migrates from nox to mise for managing linting tools.
- Configures mise to cache dependencies for faster CI execution.
- Updates the linting job to use `mise run lint` to execute the linters.