### PR TITLE
feat: support postgres `Interval` type (mapping and filtering)

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,6 @@ class Query:
     id
     name
   }
-
   # Nested filters
   users(filter: { posts: { title: { contains: "GraphQL" } } }) {
     id
@@ -522,9 +521,24 @@ class Query:
       title
     }
   }
+
+  # Compare interval component
+  tasks(filter: { duration: { days: { gt: 2 } } }) {
+    id
+    name
+    duration
+  }
+
+  # Direct interval comparison
+  tasks(filter: { duration: { gt: "P2DT5H" } }) {
+    id
+    name
+    duration
+  }
 }
 ```
 
+</details>
 </details>
 
 Strawchemy supports a wide range of filter operations:
@@ -537,6 +551,7 @@ Strawchemy supports a wide range of filter operations:
 - **Date**: `year`, `month`, `day`, `weekDay`, `week`, `quarter`, `isoYear`, `isoWeekDay`
 - **DateTime**: All Date filters plus `hour`, `minute`, `second`
 - **Time**: `hour`, `minute`, `second`
+- **Interval**: numeric filters, plus `days`, `hours`, `minutes`, `seconds`
 - **Logical**: `_and`, `_or`, `_not`
 
 ### Geo Filters

--- a/README.md
+++ b/README.md
@@ -548,10 +548,10 @@ Strawchemy supports a wide range of filter operations:
 - **String**: `like`, `nlike`, `ilike`, `nilike`, `regexp`, `nregexp`, `startswith`, `endswith`, `contains`, `istartswith`, `iendswith`, `icontains`
 - **JSON**: `contains`, `containedIn`, `hasKey`, `hasKeyAll`, `hasKeyAny`
 - **Array**: `contains`, `containedIn`, `overlap`
-- **Date**: `year`, `month`, `day`, `weekDay`, `week`, `quarter`, `isoYear`, `isoWeekDay`
+- **Date**: numeric filters on plain dates, plus `year`, `month`, `day`, `weekDay`, `week`, `quarter`, `isoYear` and `isoWeekDay` filters
 - **DateTime**: All Date filters plus `hour`, `minute`, `second`
-- **Time**: `hour`, `minute`, `second`
-- **Interval**: numeric filters, plus `days`, `hours`, `minutes`, `seconds`
+- **Time**: numeric filters on plain times, plus `hour`, `minute` and `second` filters
+- **Interval**: numeric filters on plain intervals, plus `days`, `hours`, `minutes` and `seconds` filters
 - **Logical**: `_and`, `_or`, `_not`
 
 ### Geo Filters

--- a/src/strawchemy/graphql/filters/__init__.py
+++ b/src/strawchemy/graphql/filters/__init__.py
@@ -12,6 +12,7 @@ from .base import (
     PostgresArrayComparison,
     TextComparison,
     TimeComparison,
+    TimeDeltaComparison,
 )
 
 __all__ = (
@@ -26,4 +27,5 @@ __all__ = (
     "PostgresArrayComparison",
     "TextComparison",
     "TimeComparison",
+    "TimeDeltaComparison",
 )

--- a/src/strawchemy/graphql/filters/base.py
+++ b/src/strawchemy/graphql/filters/base.py
@@ -30,6 +30,7 @@ __all__ = (
     "PostgresArrayComparison",
     "TextComparison",
     "TimeComparison",
+    "TimeDeltaComparison",
 )
 
 T = TypeVar("T")
@@ -287,6 +288,18 @@ class TimeComparison(GraphQLComparison[ModelT, ModelFieldT], Generic[AnyNumericC
     hour: AnyNumericComparison | None = None
     minute: AnyNumericComparison | None = None
     second: AnyNumericComparison | None = None
+
+    @override
+    @classmethod
+    def field_name(cls) -> str:
+        return _normalize_field_name(time)
+
+
+class TimeDeltaComparison(GraphQLComparison[ModelT, ModelFieldT], Generic[AnyNumericComparison, ModelT, ModelFieldT]):
+    days: AnyNumericComparison | None = None
+    hours: AnyNumericComparison | None = None
+    minutes: AnyNumericComparison | None = None
+    seconds: AnyNumericComparison | None = None
 
     @override
     @classmethod

--- a/src/strawchemy/sqlalchemy/filters/__init__.py
+++ b/src/strawchemy/sqlalchemy/filters/__init__.py
@@ -7,6 +7,7 @@ from .base import (
     NumericSQLAlchemyFilter,
     SQLAlchemyFilterBase,
     TextSQLAlchemyFilter,
+    TimeDeltaSQLAlchemyFilter,
     TimeSQLAlchemyFilter,
 )
 from .postgresql import JSONBSQLAlchemyFilter, PostgresArraySQLAlchemyFilter
@@ -22,5 +23,6 @@ __all__ = (
     "PostgresArraySQLAlchemyFilter",
     "SQLAlchemyFilterBase",
     "TextSQLAlchemyFilter",
+    "TimeDeltaSQLAlchemyFilter",
     "TimeSQLAlchemyFilter",
 )

--- a/src/strawchemy/sqlalchemy/inspector.py
+++ b/src/strawchemy/sqlalchemy/inspector.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from datetime import date, datetime, time
+from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, TypeVar, override
 
@@ -20,6 +20,7 @@ from .filters import (
     NumericSQLAlchemyFilter,
     SQLAlchemyFilterBase,
     TextSQLAlchemyFilter,
+    TimeDeltaSQLAlchemyFilter,
     TimeSQLAlchemyFilter,
 )
 from .filters.postgresql import JSONBSQLAlchemyFilter, PostgresArraySQLAlchemyFilter
@@ -40,6 +41,7 @@ T = TypeVar("T", bound=Any)
 
 _DEFAULT_FILTERS_MAP: FilterMap = OrderedDict(
     {
+        (timedelta,): TimeDeltaSQLAlchemyFilter,
         (datetime,): DateTimeSQLAlchemyFilter,
         (time,): TimeSQLAlchemyFilter,
         (date,): DateSQLAlchemyFilter,

--- a/src/strawchemy/strawberry/inspector.py
+++ b/src/strawchemy/strawberry/inspector.py
@@ -4,7 +4,13 @@ from typing import TYPE_CHECKING, Any, override
 
 from strawchemy.dto import DTOConfig, DTOFieldDefinition, ModelFieldT, ModelT
 from strawchemy.graphql.dto import OrderByEnum
-from strawchemy.graphql.filters import DateComparison, GraphQLComparison, GraphQLFilter, TimeComparison
+from strawchemy.graphql.filters import (
+    DateComparison,
+    GraphQLComparison,
+    GraphQLFilter,
+    TimeComparison,
+    TimeDeltaComparison,
+)
 from strawchemy.graphql.inspector import GraphQLInspectorProtocol
 
 from ._utils import pydantic_from_strawberry_type
@@ -25,6 +31,8 @@ class _StrawberryModelInspector(GraphQLInspectorProtocol[ModelT, ModelFieldT]):
     def _register_sub_types(self, comparison_type: type[GraphQLFilter[ModelT, ModelFieldT]]) -> None:
         if issubclass(comparison_type, TimeComparison | DateComparison):
             self._registry.register_comparison_type(self._inspector.get_type_comparison(int))
+        if issubclass(comparison_type, TimeDeltaComparison):
+            self._registry.register_comparison_type(self._inspector.get_type_comparison(float))
 
     @override
     def field_definitions(

--- a/src/strawchemy/strawberry/scalars.py
+++ b/src/strawchemy/strawberry/scalars.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from functools import partial
+from typing import NewType
+
+from pydantic import TypeAdapter
+from strawberry import scalar
+
+__all__ = ("Interval",)
+
+_IntervalType = TypeAdapter(timedelta)
+
+Interval = scalar(
+    NewType("Interval", timedelta),
+    description=(
+        "The `Interval` scalar type represents a duration of time as specified by "
+        "[ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations)."
+    ),
+    parse_value=_IntervalType.validate_python,
+    serialize=partial(_IntervalType.dump_python, mode="json"),
+    specified_by_url="https://en.wikipedia.org/wiki/ISO_8601#Durations",
+)

--- a/tests/integration/__snapshots__/test_filters.ambr
+++ b/tests/integration/__snapshots__/test_filters.ambr
@@ -29,42 +29,6 @@
     AND (sql_data_types.str_col LIKE '%' || :str_col_1 || '%' ESCAPE '/')
   '''
 # ---
-# name: test_combined_filters[session-tracked-async-asyncpg_engine]
-  '''
-  SELECT sql_data_types.str_col,
-         sql_data_types.int_col,
-         sql_data_types.bool_col,
-         sql_data_types.id
-  FROM sql_data_types AS sql_data_types
-  WHERE sql_data_types.bool_col = TRUE
-    AND sql_data_types.int_col > :int_col_1
-    AND (sql_data_types.str_col LIKE '%' || :str_col_1 || '%' ESCAPE '/')
-  '''
-# ---
-# name: test_combined_filters[session-tracked-async-psycopg_async_engine]
-  '''
-  SELECT sql_data_types.str_col,
-         sql_data_types.int_col,
-         sql_data_types.bool_col,
-         sql_data_types.id
-  FROM sql_data_types AS sql_data_types
-  WHERE sql_data_types.bool_col = TRUE
-    AND sql_data_types.int_col > :int_col_1
-    AND (sql_data_types.str_col LIKE '%' || :str_col_1 || '%' ESCAPE '/')
-  '''
-# ---
-# name: test_combined_filters[session-tracked-sync-psycopg_engine]
-  '''
-  SELECT sql_data_types.str_col,
-         sql_data_types.int_col,
-         sql_data_types.bool_col,
-         sql_data_types.id
-  FROM sql_data_types AS sql_data_types
-  WHERE sql_data_types.bool_col = TRUE
-    AND sql_data_types.int_col > :int_col_1
-    AND (sql_data_types.str_col LIKE '%' || :str_col_1 || '%' ESCAPE '/')
-  '''
-# ---
 # name: test_complex_logical_operators[session-tracked-async-asyncpg_engine]
   '''
   SELECT sql_data_types.str_col,
@@ -833,6 +797,30 @@
   WHERE sql_data_types.time_col = :time_col_1
   '''
 # ---
+# name: test_eq[session-tracked-timedelta-async-asyncpg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.time_delta_col = :time_delta_col_1
+  '''
+# ---
+# name: test_eq[session-tracked-timedelta-async-psycopg_async_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.time_delta_col = :time_delta_col_1
+  '''
+# ---
+# name: test_eq[session-tracked-timedelta-sync-psycopg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.time_delta_col = :time_delta_col_1
+  '''
+# ---
 # name: test_filter_on_paginated_query[session-tracked-async-asyncpg_engine]
   '''
   SELECT sql_data_types.int_col,
@@ -1022,6 +1010,30 @@
   WHERE sql_data_types.time_col > :time_col_1
   '''
 # ---
+# name: test_gt[session-tracked-timedelta-gt-async-asyncpg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.time_delta_col > :time_delta_col_1
+  '''
+# ---
+# name: test_gt[session-tracked-timedelta-gt-async-psycopg_async_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.time_delta_col > :time_delta_col_1
+  '''
+# ---
+# name: test_gt[session-tracked-timedelta-gt-sync-psycopg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.time_delta_col > :time_delta_col_1
+  '''
+# ---
 # name: test_gte[session-tracked-date-gte-async-asyncpg_engine]
   '''
   SELECT sql_data_types.date_col,
@@ -1164,6 +1176,30 @@
          sql_data_types.id
   FROM sql_data_types AS sql_data_types
   WHERE sql_data_types.time_col >= :time_col_1
+  '''
+# ---
+# name: test_gte[session-tracked-timedelta-gte-async-asyncpg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.time_delta_col >= :time_delta_col_1
+  '''
+# ---
+# name: test_gte[session-tracked-timedelta-gte-async-psycopg_async_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.time_delta_col >= :time_delta_col_1
+  '''
+# ---
+# name: test_gte[session-tracked-timedelta-gte-sync-psycopg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.time_delta_col >= :time_delta_col_1
   '''
 # ---
 # name: test_in[session-tracked-bool-async-asyncpg_engine]
@@ -1356,6 +1392,30 @@
          sql_data_types.id
   FROM sql_data_types AS sql_data_types
   WHERE sql_data_types.time_col IN (__[POSTCOMPILE_time_col_1])
+  '''
+# ---
+# name: test_in[session-tracked-timedelta-async-asyncpg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.time_delta_col IN (__[POSTCOMPILE_time_delta_col_1])
+  '''
+# ---
+# name: test_in[session-tracked-timedelta-async-psycopg_async_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.time_delta_col IN (__[POSTCOMPILE_time_delta_col_1])
+  '''
+# ---
+# name: test_in[session-tracked-timedelta-sync-psycopg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.time_delta_col IN (__[POSTCOMPILE_time_delta_col_1])
   '''
 # ---
 # name: test_isnull[session-tracked-async-asyncpg_engine]
@@ -1646,6 +1706,30 @@
   WHERE sql_data_types.time_col < :time_col_1
   '''
 # ---
+# name: test_lt[session-tracked-timedelta-lt-async-asyncpg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.time_delta_col < :time_delta_col_1
+  '''
+# ---
+# name: test_lt[session-tracked-timedelta-lt-async-psycopg_async_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.time_delta_col < :time_delta_col_1
+  '''
+# ---
+# name: test_lt[session-tracked-timedelta-lt-sync-psycopg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.time_delta_col < :time_delta_col_1
+  '''
+# ---
 # name: test_lte[session-tracked-date-lte-async-asyncpg_engine]
   '''
   SELECT sql_data_types.date_col,
@@ -1788,6 +1872,30 @@
          sql_data_types.id
   FROM sql_data_types AS sql_data_types
   WHERE sql_data_types.time_col <= :time_col_1
+  '''
+# ---
+# name: test_lte[session-tracked-timedelta-lte-async-asyncpg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.time_delta_col <= :time_delta_col_1
+  '''
+# ---
+# name: test_lte[session-tracked-timedelta-lte-async-psycopg_async_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.time_delta_col <= :time_delta_col_1
+  '''
+# ---
+# name: test_lte[session-tracked-timedelta-lte-sync-psycopg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.time_delta_col <= :time_delta_col_1
   '''
 # ---
 # name: test_neq[session-tracked-bool-async-asyncpg_engine]
@@ -2006,6 +2114,30 @@
   WHERE sql_data_types.time_col != :time_col_1
   '''
 # ---
+# name: test_neq[session-tracked-timedelta-async-asyncpg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.time_delta_col != :time_delta_col_1
+  '''
+# ---
+# name: test_neq[session-tracked-timedelta-async-psycopg_async_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.time_delta_col != :time_delta_col_1
+  '''
+# ---
+# name: test_neq[session-tracked-timedelta-sync-psycopg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.time_delta_col != :time_delta_col_1
+  '''
+# ---
 # name: test_nin[session-tracked-bool-async-asyncpg_engine]
   '''
   SELECT sql_data_types.bool_col,
@@ -2196,6 +2328,30 @@
          sql_data_types.id
   FROM sql_data_types AS sql_data_types
   WHERE (sql_data_types.time_col NOT IN (__[POSTCOMPILE_time_col_1]))
+  '''
+# ---
+# name: test_nin[session-tracked-timedelta-async-asyncpg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE (sql_data_types.time_delta_col NOT IN (__[POSTCOMPILE_time_delta_col_1]))
+  '''
+# ---
+# name: test_nin[session-tracked-timedelta-async-psycopg_async_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE (sql_data_types.time_delta_col NOT IN (__[POSTCOMPILE_time_delta_col_1]))
+  '''
+# ---
+# name: test_nin[session-tracked-timedelta-sync-psycopg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE (sql_data_types.time_delta_col NOT IN (__[POSTCOMPILE_time_delta_col_1]))
   '''
 # ---
 # name: test_no_filtering[session-tracked-async-asyncpg_engine]
@@ -2709,6 +2865,114 @@
   FROM sql_data_types AS sql_data_types
   WHERE EXTRACT(SECOND
                 FROM sql_data_types.time_col) = :param_1
+  '''
+# ---
+# name: test_timedelta_components[session-tracked-days-async-asyncpg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE EXTRACT(EPOCH
+                FROM sql_data_types.time_delta_col) / CAST(:param_1 AS NUMERIC) = :param_2
+  '''
+# ---
+# name: test_timedelta_components[session-tracked-days-async-psycopg_async_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE EXTRACT(EPOCH
+                FROM sql_data_types.time_delta_col) / CAST(:param_1 AS NUMERIC) = :param_2
+  '''
+# ---
+# name: test_timedelta_components[session-tracked-days-sync-psycopg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE EXTRACT(EPOCH
+                FROM sql_data_types.time_delta_col) / CAST(:param_1 AS NUMERIC) = :param_2
+  '''
+# ---
+# name: test_timedelta_components[session-tracked-hours-async-asyncpg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE EXTRACT(EPOCH
+                FROM sql_data_types.time_delta_col) / CAST(:param_1 AS NUMERIC) = :param_2
+  '''
+# ---
+# name: test_timedelta_components[session-tracked-hours-async-psycopg_async_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE EXTRACT(EPOCH
+                FROM sql_data_types.time_delta_col) / CAST(:param_1 AS NUMERIC) = :param_2
+  '''
+# ---
+# name: test_timedelta_components[session-tracked-hours-sync-psycopg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE EXTRACT(EPOCH
+                FROM sql_data_types.time_delta_col) / CAST(:param_1 AS NUMERIC) = :param_2
+  '''
+# ---
+# name: test_timedelta_components[session-tracked-minutes-async-asyncpg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE EXTRACT(EPOCH
+                FROM sql_data_types.time_delta_col) / CAST(:param_1 AS NUMERIC) = :param_2
+  '''
+# ---
+# name: test_timedelta_components[session-tracked-minutes-async-psycopg_async_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE EXTRACT(EPOCH
+                FROM sql_data_types.time_delta_col) / CAST(:param_1 AS NUMERIC) = :param_2
+  '''
+# ---
+# name: test_timedelta_components[session-tracked-minutes-sync-psycopg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE EXTRACT(EPOCH
+                FROM sql_data_types.time_delta_col) / CAST(:param_1 AS NUMERIC) = :param_2
+  '''
+# ---
+# name: test_timedelta_components[session-tracked-totalSeconds-async-asyncpg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE EXTRACT(EPOCH
+                FROM sql_data_types.time_delta_col) = :param_1
+  '''
+# ---
+# name: test_timedelta_components[session-tracked-totalSeconds-async-psycopg_async_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE EXTRACT(EPOCH
+                FROM sql_data_types.time_delta_col) = :param_1
+  '''
+# ---
+# name: test_timedelta_components[session-tracked-totalSeconds-sync-psycopg_engine]
+  '''
+  SELECT sql_data_types.time_delta_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE EXTRACT(EPOCH
+                FROM sql_data_types.time_delta_col) = :param_1
   '''
 # ---
 # name: test_uuid_filters[session-tracked-async-asyncpg_engine]

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 from dataclasses import dataclass
-from datetime import UTC, date, datetime, time
+from datetime import UTC, date, datetime, time, timedelta
 from decimal import Decimal
 from importlib.util import find_spec
 from typing import TYPE_CHECKING, Any, cast
@@ -12,6 +12,7 @@ import pytest
 import sqlparse
 from pytest_databases.docker.postgres import _provide_postgres_service
 from pytest_lazy_fixtures import lf
+from strawchemy.strawberry.scalars import Interval
 
 from sqlalchemy import URL, Engine, Executable, Insert, MetaData, NullPool, create_engine, insert
 from sqlalchemy.event import listens_for
@@ -55,7 +56,7 @@ __all__ = (
     "session",
 )
 
-scalar_overrides: dict[object, Any] = {dict[str, Any]: JSON}
+scalar_overrides: dict[object, Any] = {dict[str, Any]: JSON, timedelta: Interval}
 
 if find_spec("geoalchemy2") is not None:
     from strawchemy.strawberry.geo import GEO_SCALAR_OVERRIDES
@@ -341,7 +342,7 @@ def raw_sql_data_types(raw_sql_data_types_container: RawRecordData) -> RawRecord
             "id": str(uuid4()),
             "date_col": date(2023, 1, 15),
             "time_col": time(14, 30, 45),
-            "time_delta_col": time(23, 59, 59),
+            "time_delta_col": timedelta(days=2, hours=23, minutes=59, seconds=59),
             "datetime_col": datetime(2023, 1, 15, 14, 30, 45, tzinfo=UTC),
             "str_col": "test string",
             "int_col": 42,
@@ -359,7 +360,7 @@ def raw_sql_data_types(raw_sql_data_types_container: RawRecordData) -> RawRecord
             "id": str(uuid4()),
             "date_col": date(2022, 12, 31),
             "time_col": time(8, 15, 0),
-            "time_delta_col": time(12, 0, 0),
+            "time_delta_col": timedelta(weeks=1, days=3, hours=12),
             "datetime_col": datetime(2022, 12, 31, 23, 59, 59, tzinfo=UTC),
             "str_col": "another string",
             "int_col": -10,
@@ -377,7 +378,7 @@ def raw_sql_data_types(raw_sql_data_types_container: RawRecordData) -> RawRecord
             "id": str(uuid4()),
             "date_col": date(2024, 2, 29),  # leap year
             "time_col": time(0, 0, 0),
-            "time_delta_col": time(1, 1, 1),
+            "time_delta_col": timedelta(microseconds=500000, seconds=1),
             "datetime_col": datetime(2024, 2, 29, 0, 0, 0, tzinfo=UTC),
             "str_col": "",  # empty string
             "int_col": 0,
@@ -401,7 +402,7 @@ def raw_sql_data_types_set1(raw_containers: RawRecordData) -> RawRecordData:
             "id": str(uuid4()),
             "date_col": date(2021, 6, 15),
             "time_col": time(10, 45, 30),
-            "time_delta_col": time(18, 30, 15),
+            "time_delta_col": timedelta(days=-5, hours=18, minutes=30, seconds=15),
             "datetime_col": datetime(2021, 6, 15, 10, 45, 30, tzinfo=UTC),
             "str_col": "data set 1 string",
             "int_col": 100,
@@ -419,7 +420,7 @@ def raw_sql_data_types_set1(raw_containers: RawRecordData) -> RawRecordData:
             "id": str(uuid4()),
             "date_col": date(2021, 7, 20),
             "time_col": time(15, 20, 10),
-            "time_delta_col": time(9, 45, 30),
+            "time_delta_col": timedelta(weeks=2, hours=9, minutes=45, seconds=30, microseconds=123456),
             "datetime_col": datetime(2021, 7, 20, 15, 20, 10, tzinfo=UTC),
             "str_col": "another set 1 string",
             "int_col": 75,
@@ -443,7 +444,7 @@ def raw_sql_data_types_set2(raw_containers: RawRecordData) -> RawRecordData:
             "id": str(uuid4()),
             "date_col": date(2020, 3, 10),
             "time_col": time(9, 15, 25),
-            "time_delta_col": time(16, 45, 0),
+            "time_delta_col": timedelta(days=30, hours=16, minutes=45),
             "datetime_col": datetime(2020, 3, 10, 9, 15, 25, tzinfo=UTC),
             "str_col": "data set 2 string",
             "int_col": 250,
@@ -461,7 +462,7 @@ def raw_sql_data_types_set2(raw_containers: RawRecordData) -> RawRecordData:
             "id": str(uuid4()),
             "date_col": date(2020, 9, 5),
             "time_col": time(13, 0, 0),
-            "time_delta_col": time(21, 15, 45),
+            "time_delta_col": timedelta(days=-10, hours=-5, minutes=15, seconds=45, microseconds=999999),
             "datetime_col": datetime(2020, 9, 5, 13, 0, 0, tzinfo=UTC),
             "str_col": "another set 2 string",
             "int_col": 180,

--- a/tests/integration/models.py
+++ b/tests/integration/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, date, datetime, time
+from datetime import UTC, date, datetime, time, timedelta
 from decimal import Decimal
 from typing import Any
 from uuid import UUID, uuid4
@@ -67,7 +67,7 @@ class SQLDataTypes(UUIDBase):
 
     date_col: Mapped[date]
     time_col: Mapped[time]
-    time_delta_col: Mapped[time]
+    time_delta_col: Mapped[timedelta]
     datetime_col: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     str_col: Mapped[str]
     int_col: Mapped[int]

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import json
 import re
-from datetime import date, datetime, time
+from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from statistics import mean, pstdev, pvariance, stdev, variance
 from typing import TYPE_CHECKING, Any, Literal
 from uuid import UUID
 
+from pydantic import TypeAdapter
 from sqlalchemy import inspect
 
 if TYPE_CHECKING:
@@ -17,6 +18,9 @@ if TYPE_CHECKING:
 
 
 __all__ = ("from_graphql_representation", "python_type", "to_graphql_representation")
+
+
+_TimeDeltaType = TypeAdapter(timedelta)
 
 
 def to_graphql_representation(value: Any, mode: Literal["input", "output"]) -> Any:
@@ -57,6 +61,8 @@ def to_graphql_representation(value: Any, mode: Literal["input", "output"]) -> A
 
     if isinstance(value, datetime | date | time):
         expected = value.isoformat()
+    elif isinstance(value, timedelta):
+        expected = _TimeDeltaType.dump_python(value, mode="json")
     elif isinstance(value, Decimal | UUID):
         expected = str(value)
 

--- a/tests/unit/mapping/__snapshots__/test_types/test_mutation_schemas[input_type].gql
+++ b/tests/unit/mapping/__snapshots__/test_types/test_mutation_schemas[input_type].gql
@@ -11,6 +11,11 @@
   scalar Decimal
   
   """
+  The `Interval` scalar type represents a duration of time as specified by [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations).
+  """
+  scalar Interval @specifiedBy(url: "https://en.wikipedia.org/wiki/ISO_8601#Durations")
+  
+  """
   The `JSON` scalar type represents JSON values as specified by [ECMA-404](https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf).
   """
   scalar JSON @specifiedBy(url: "https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf")
@@ -28,7 +33,7 @@
     id: UUID!
     dateCol: Date!
     timeCol: Time!
-    timeDeltaCol: Time!
+    timeDeltaCol: Interval!
     datetimeCol: DateTime!
     strCol: String!
     intCol: Int!
@@ -45,7 +50,7 @@
     id: UUID!
     dateCol: Date!
     timeCol: Time!
-    timeDeltaCol: Time!
+    timeDeltaCol: Interval!
     datetimeCol: DateTime!
     strCol: String!
     intCol: Int!

--- a/tests/unit/mapping/__snapshots__/test_types/test_schemas[filters].gql
+++ b/tests/unit/mapping/__snapshots__/test_types/test_schemas[filters].gql
@@ -116,6 +116,30 @@
   }
   
   """
+  The `Interval` scalar type represents a duration of time as specified by [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations).
+  """
+  scalar Interval @specifiedBy(url: "https://en.wikipedia.org/wiki/ISO_8601#Durations")
+  
+  """
+  Boolean expression to compare fields of type Time. All fields are combined with logical 'AND'
+  """
+  input IntervalComparison {
+    eq: Interval
+    neq: Interval
+    isNull: Boolean
+    in_: [Interval!]
+    nin_: [Interval!]
+    gt: Interval
+    gte: Interval
+    lt: Interval
+    lte: Interval
+    days: FloatComparison
+    hours: FloatComparison
+    minutes: FloatComparison
+    seconds: FloatComparison
+  }
+  
+  """
   The `JSON` scalar type represents JSON values as specified by [ECMA-404](https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf).
   """
   scalar JSON @specifiedBy(url: "https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf")
@@ -151,7 +175,7 @@
     id: UUIDComparison
     dateCol: DateComparison
     timeCol: TimeComparison
-    timeDeltaCol: TimeComparison
+    timeDeltaCol: IntervalComparison
     datetimeCol: DateTimeComparison
     strCol: StringComparison
     intCol: IntComparison
@@ -168,7 +192,7 @@
     id: UUID!
     dateCol: Date!
     timeCol: Time!
-    timeDeltaCol: Time!
+    timeDeltaCol: Interval!
     datetimeCol: DateTime!
     strCol: String!
     intCol: Int!

--- a/tests/unit/mapping/__snapshots__/test_types/test_schemas[root_aggregations].gql
+++ b/tests/unit/mapping/__snapshots__/test_types/test_schemas[root_aggregations].gql
@@ -11,6 +11,11 @@
   scalar Decimal
   
   """
+  The `Interval` scalar type represents a duration of time as specified by [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations).
+  """
+  scalar Interval @specifiedBy(url: "https://en.wikipedia.org/wiki/ISO_8601#Durations")
+  
+  """
   The `JSON` scalar type represents JSON values as specified by [ECMA-404](https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf).
   """
   scalar JSON @specifiedBy(url: "https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf")
@@ -44,7 +49,6 @@
   type SQLDataTypesMinMaxFields {
     dateCol: Date
     timeCol: Time
-    timeDeltaCol: Time
     datetimeCol: DateTime
     strCol: String
     intCol: Int
@@ -59,6 +63,7 @@
   }
   
   type SQLDataTypesSumFields {
+    timeDeltaCol: Interval
     strCol: String
     intCol: Int
     floatCol: Float
@@ -70,7 +75,7 @@
     id: UUID!
     dateCol: Date!
     timeCol: Time!
-    timeDeltaCol: Time!
+    timeDeltaCol: Interval!
     datetimeCol: DateTime!
     strCol: String!
     intCol: Int!

--- a/tests/unit/models.py
+++ b/tests/unit/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import enum
-from datetime import date, datetime, time
+from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from typing import Any
 from uuid import UUID, uuid4
@@ -154,7 +154,7 @@ class SQLDataTypes(UUIDBase):
 
     date_col: Mapped[date]
     time_col: Mapped[time]
-    time_delta_col: Mapped[time]
+    time_delta_col: Mapped[timedelta]
     datetime_col: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     str_col: Mapped[str]
     int_col: Mapped[int]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

-

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Adds support for the Postgres `Interval` type, enabling mapping and filtering of `timedelta` values in GraphQL queries. This includes adding a new `TimeDeltaSQLAlchemyFilter` and a new `Interval` scalar type.

New Features:
- Adds support for filtering based on `Interval` type, including comparison operations and component-based filtering (days, hours, minutes, seconds).
- Introduces a new `Interval` scalar type to represent time durations in GraphQL schema, adhering to ISO 8601 duration format.

Tests:
- Adds integration tests for filtering `timedelta` columns with various comparison operators and component extractions.