### PR TITLE
feat(filters): add insensitive regexp variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,18 +596,18 @@ Now you can use various filter operations in your GraphQL queries:
 
 Strawchemy supports a wide range of filter operations:
 
-| Data Type/Category                      | Filter Operations                                                                                                                                         |
-| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Common to most types**                | `eq`, `neq`, `isNull`, `in`, `nin`                                                                                                                        |
-| **Numeric types (Int, Float, Decimal)** | `gt`, `gte`, `lt`, `lte`                                                                                                                                  |
-| **String**                              | order filter, plus `like`, `nlike`, `ilike`, `nilike`, `regexp`, `nregexp`, `startswith`, `endswith`, `contains`, `istartswith`, `iendswith`, `icontains` |
-| **JSON**                                | `contains`, `containedIn`, `hasKey`, `hasKeyAll`, `hasKeyAny`                                                                                             |
-| **Array**                               | `contains`, `containedIn`, `overlap`                                                                                                                      |
-| **Date**                                | order filters on plain dates, plus `year`, `month`, `day`, `weekDay`, `week`, `quarter`, `isoYear` and `isoWeekDay` filters                               |
-| **DateTime**                            | All Date filters plus `hour`, `minute`, `second`                                                                                                          |
-| **Time**                                | order filters on plain times, plus `hour`, `minute` and `second` filters                                                                                  |
-| **Interval**                            | order filters on plain intervals, plus `days`, `hours`, `minutes` and `seconds` filters                                                                   |
-| **Logical**                             | `_and`, `_or`, `_not`                                                                                                                                     |
+| Data Type/Category                      | Filter Operations                                                                                                                                                                |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Common to most types**                | `eq`, `neq`, `isNull`, `in`, `nin`                                                                                                                                               |
+| **Numeric types (Int, Float, Decimal)** | `gt`, `gte`, `lt`, `lte`                                                                                                                                                         |
+| **String**                              | order filter, plus `like`, `nlike`, `ilike`, `nilike`, `regexp`, `iregexp`, `nregexp`, `inregexp`, `startswith`, `endswith`, `contains`, `istartswith`, `iendswith`, `icontains` |
+| **JSON**                                | `contains`, `containedIn`, `hasKey`, `hasKeyAll`, `hasKeyAny`                                                                                                                    |
+| **Array**                               | `contains`, `containedIn`, `overlap`                                                                                                                                             |
+| **Date**                                | order filters on plain dates, plus `year`, `month`, `day`, `weekDay`, `week`, `quarter`, `isoYear` and `isoWeekDay` filters                                                      |
+| **DateTime**                            | All Date filters plus `hour`, `minute`, `second`                                                                                                                                 |
+| **Time**                                | order filters on plain times, plus `hour`, `minute` and `second` filters                                                                                                         |
+| **Interval**                            | order filters on plain intervals, plus `days`, `hours`, `minutes` and `seconds` filters                                                                                          |
+| **Logical**                             | `_and`, `_or`, `_not`                                                                                                                                                            |
 
 ### Geo Filters
 

--- a/src/strawchemy/graphql/filters/base.py
+++ b/src/strawchemy/graphql/filters/base.py
@@ -173,7 +173,9 @@ class TextComparison(GraphQLComparison[ModelT, ModelFieldT]):
     ilike: str | None = None
     nilike: str | None = None
     regexp: RegexPatternStr | None = None
+    iregexp: RegexPatternStr | None = None
     nregexp: RegexPatternStr | None = None
+    inregexp: RegexPatternStr | None = None
     startswith: str | None = None
     endswith: str | None = None
     contains: str | None = None

--- a/src/strawchemy/sqlalchemy/filters/base.py
+++ b/src/strawchemy/sqlalchemy/filters/base.py
@@ -153,6 +153,10 @@ class TextSQLAlchemyFilter(TextComparison[DeclarativeBase, QueryableAttribute[An
             expressions.append(model_attribute.regexp_match(self.regexp))
         if "nregexp" in self.model_fields_set:
             expressions.append(not_(model_attribute.regexp_match(self.nregexp)))
+        if "iregexp" in self.model_fields_set:
+            expressions.append(func.lower(model_attribute).regexp_match(self.iregexp))
+        if "inregexp" in self.model_fields_set:
+            expressions.append(not_(func.lower(model_attribute).regexp_match(self.inregexp)))
 
         return expressions
 

--- a/tests/integration/__snapshots__/test_filters.ambr
+++ b/tests/integration/__snapshots__/test_filters.ambr
@@ -2714,6 +2714,78 @@
   WHERE lower(sql_data_types.str_col) LIKE lower(:str_col_1)
   '''
 # ---
+# name: test_string_filters[session-tracked-inregexp0-async-asyncpg_engine]
+  '''
+  SELECT sql_data_types.str_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.str_col < not regexp > :str_col_1
+  '''
+# ---
+# name: test_string_filters[session-tracked-inregexp0-async-psycopg_async_engine]
+  '''
+  SELECT sql_data_types.str_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.str_col < not regexp > :str_col_1
+  '''
+# ---
+# name: test_string_filters[session-tracked-inregexp0-sync-psycopg_engine]
+  '''
+  SELECT sql_data_types.str_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE sql_data_types.str_col < not regexp > :str_col_1
+  '''
+# ---
+# name: test_string_filters[session-tracked-inregexp1-async-asyncpg_engine]
+  '''
+  SELECT sql_data_types.str_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE lower(sql_data_types.str_col) < not regexp > :lower_1
+  '''
+# ---
+# name: test_string_filters[session-tracked-inregexp1-async-psycopg_async_engine]
+  '''
+  SELECT sql_data_types.str_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE lower(sql_data_types.str_col) < not regexp > :lower_1
+  '''
+# ---
+# name: test_string_filters[session-tracked-inregexp1-sync-psycopg_engine]
+  '''
+  SELECT sql_data_types.str_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE lower(sql_data_types.str_col) < not regexp > :lower_1
+  '''
+# ---
+# name: test_string_filters[session-tracked-iregexp-async-asyncpg_engine]
+  '''
+  SELECT sql_data_types.str_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE lower(sql_data_types.str_col) < regexp > :lower_1
+  '''
+# ---
+# name: test_string_filters[session-tracked-iregexp-async-psycopg_async_engine]
+  '''
+  SELECT sql_data_types.str_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE lower(sql_data_types.str_col) < regexp > :lower_1
+  '''
+# ---
+# name: test_string_filters[session-tracked-iregexp-sync-psycopg_engine]
+  '''
+  SELECT sql_data_types.str_col,
+         sql_data_types.id
+  FROM sql_data_types AS sql_data_types
+  WHERE lower(sql_data_types.str_col) < regexp > :lower_1
+  '''
+# ---
 # name: test_string_filters[session-tracked-istartswith-async-asyncpg_engine]
   '''
   SELECT sql_data_types.str_col,

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -362,7 +362,7 @@ def raw_sql_data_types(raw_sql_data_types_container: RawRecordData) -> RawRecord
             "time_col": time(8, 15, 0),
             "time_delta_col": timedelta(weeks=1, days=3, hours=12),
             "datetime_col": datetime(2022, 12, 31, 23, 59, 59, tzinfo=UTC),
-            "str_col": "another string",
+            "str_col": "another STRING",
             "int_col": -10,
             "float_col": 2.71828,
             "decimal_col": Decimal("-99.99"),

--- a/tests/integration/test_filters.py
+++ b/tests/integration/test_filters.py
@@ -191,7 +191,7 @@ async def test_isnull(
 @pytest.mark.parametrize(
     ("field_name", "values", "expected_ids"),
     [
-        pytest.param("strCol", ["test string", "another string"], [0, 1], id="str"),
+        pytest.param("strCol", ["test string", "another STRING"], [0, 1], id="str"),
         pytest.param("intCol", [42, -10], [0, 1], id="int"),
         pytest.param("floatCol", [3.14159, 2.71828], [0, 1], id="float"),
         pytest.param("decimalCol", [Decimal("123.45"), Decimal("-99.99")], [0, 1], id="decimal"),
@@ -252,7 +252,7 @@ async def test_in(
 @pytest.mark.parametrize(
     ("field_name", "values", "expected_ids"),
     [
-        pytest.param("strCol", ["test string", "another string"], [2], id="str"),
+        pytest.param("strCol", ["test string", "another STRING"], [2], id="str"),
         pytest.param("intCol", [42, -10], [2], id="int"),
         pytest.param("floatCol", [3.14159, 2.71828], [2], id="float"),
         pytest.param("decimalCol", [Decimal("123.45"), Decimal("-99.99")], [2], id="decimal"),
@@ -479,18 +479,20 @@ async def test_lte(
 @pytest.mark.parametrize(
     ("filter_name", "value", "expected_ids"),
     [
-        pytest.param("like", "%string%", [0, 1], id="like"),
-        pytest.param("nlike", "%string%", [2], id="nlike"),
+        pytest.param("like", "%string%", [0], id="like"),
+        pytest.param("nlike", "%string%", [1, 2], id="nlike"),
         pytest.param("ilike", "%STRING%", [0, 1], id="ilike"),
         pytest.param("nilike", "%STRING%", [2], id="nilike"),
         pytest.param("startswith", "test", [0], id="startswith"),
-        pytest.param("endswith", "string", [0, 1], id="endswith"),
-        pytest.param("contains", "string", [0, 1], id="contains"),
+        pytest.param("endswith", "string", [0], id="endswith"),
+        pytest.param("contains", "string", [0], id="contains"),
         pytest.param("istartswith", "TEST", [0], id="istartswith"),
         pytest.param("iendswith", "STRING", [0, 1], id="iendswith"),
         pytest.param("icontains", "STRING", [0, 1], id="icontains"),
         pytest.param("regexp", "^test", [0], id="regexp"),
-        pytest.param("nregexp", "^test", [1, 2], id="nregexp"),
+        pytest.param("iregexp", ".*string$", [0, 1], id="iregexp"),
+        pytest.param("nregexp", "^test", [1, 2], id="inregexp"),
+        pytest.param("inregexp", ".*string$", [2], id="inregexp"),
     ],
 )
 @pytest.mark.snapshot

--- a/tests/unit/mapping/__snapshots__/test_types/test_schemas[aggregation_filters].gql
+++ b/tests/unit/mapping/__snapshots__/test_types/test_schemas[aggregation_filters].gql
@@ -128,7 +128,9 @@
     ilike: String
     nilike: String
     regexp: String
+    iregexp: String
     nregexp: String
+    inregexp: String
     startswith: String
     endswith: String
     contains: String

--- a/tests/unit/mapping/__snapshots__/test_types/test_schemas[filters].gql
+++ b/tests/unit/mapping/__snapshots__/test_types/test_schemas[filters].gql
@@ -236,7 +236,9 @@
     ilike: String
     nilike: String
     regexp: String
+    iregexp: String
     nregexp: String
+    inregexp: String
     startswith: String
     endswith: String
     contains: String


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

-

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Adds case-insensitive regular expression filter options for string fields, including `iregexp` and `inregexp`.

Enhancements:
- Adds `iregexp` and `inregexp` filter options to string fields to enable case-insensitive regular expression matching.
- Updates documentation to reflect the addition of the new filter options.
- Adds integration tests for the new filter options.