### PR TITLE
fix(query-hooks): enforce column only attributs in QueryHook.load_columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,8 +428,8 @@ from strawberry import Info
 class FruitTypeWithDescription:
     instance: ModelInstance[Fruit]
 
-    # Use QueryHook with always_load parameter to ensure columns are loaded
-    @strawchemy.field(query_hook=QueryHook(always_load=[Fruit.name, Fruit.adjectives]))
+    # Use QueryHook with load_columns parameter to ensure columns are loaded
+    @strawchemy.field(query_hook=QueryHook(load_columns=[Fruit.name, Fruit.adjectives]))
     def description(self) -> str:
         return f"The {self.instance.name} is {', '.join(self.instance.adjectives)}"
 

--- a/src/strawchemy/sqlalchemy/exceptions.py
+++ b/src/strawchemy/sqlalchemy/exceptions.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__all__ = ("QueryResultError", "TranspilingError")
+__all__ = ("QueryHookError", "QueryResultError", "TranspilingError")
 
 
 class TranspilingError(Exception):
@@ -10,3 +10,6 @@ class TranspilingError(Exception):
 
 
 class QueryResultError(Exception): ...
+
+
+class QueryHookError(Exception): ...

--- a/src/strawchemy/sqlalchemy/typing.py
+++ b/src/strawchemy/sqlalchemy/typing.py
@@ -47,12 +47,13 @@ QueryExecutorT = TypeVar("QueryExecutorT", bound="QueryExecutor[Any]")
 
 RelationshipSide: TypeAlias = Literal["parent", "target"]
 StatementType = Literal["lambda", "select"]
+LoadMode = Literal["load_options", "statement"]
 SQLAlchemyQueryNode: TypeAlias = "QueryNode[DeclarativeBase, QueryableAttribute[Any]]"
 SQLAlchemyOrderByNode: TypeAlias = "OrderByNode[DeclarativeBase, QueryableAttribute[Any]]"
 type ColumnOrRelationship = "Column[Any] | RelationshipProperty[Any]"
 FunctionGenerator: TypeAlias = "Callable[..., Function[Any]]"
-QueryHookCallableWithoutInfo: TypeAlias = "Callable[[Select[tuple[QueryHookDeclarativeT]], AliasedClass[QueryHookDeclarativeT]], QueryHookResult[QueryHookDeclarativeT]]"
-QueryHookCallableWithInfo: TypeAlias = "Callable[[Select[tuple[QueryHookDeclarativeT]], AliasedClass[QueryHookDeclarativeT], Info[Any, Any]], QueryHookResult[QueryHookDeclarativeT]]"
+QueryHookCallableWithoutInfo: TypeAlias = "Callable[[Select[tuple[QueryHookDeclarativeT]], AliasedClass[QueryHookDeclarativeT], LoadMode], QueryHookResult[QueryHookDeclarativeT]]"
+QueryHookCallableWithInfo: TypeAlias = "Callable[[Select[tuple[QueryHookDeclarativeT]], AliasedClass[QueryHookDeclarativeT], LoadMode, Info[Any, Any]], QueryHookResult[QueryHookDeclarativeT]]"
 QueryHookCallable: TypeAlias = (
     "QueryHookCallableWithoutInfo[QueryHookDeclarativeT] | QueryHookCallableWithInfo[QueryHookDeclarativeT]"
 )

--- a/tests/integration/__snapshots__/test_query_hooks.ambr
+++ b/tests/integration/__snapshots__/test_query_hooks.ambr
@@ -15,6 +15,75 @@
   FROM fruit AS fruit
   '''
 # ---
+# name: test_always_load_column_hook[session-tracked-fruits-async-asyncpg_engine]
+  '''
+  SELECT fruit.name,
+         fruit.adjectives,
+         fruit.id
+  FROM fruit AS fruit
+  '''
+# ---
+# name: test_always_load_column_hook[session-tracked-fruits-async-psycopg_async_engine]
+  '''
+  SELECT fruit.name,
+         fruit.adjectives,
+         fruit.id
+  FROM fruit AS fruit
+  '''
+# ---
+# name: test_always_load_column_hook[session-tracked-fruits-sync-psycopg_engine]
+  '''
+  SELECT fruit.name,
+         fruit.adjectives,
+         fruit.id
+  FROM fruit AS fruit
+  '''
+# ---
+# name: test_always_load_column_hook[session-tracked-fruitsPaginated-async-asyncpg_engine]
+  '''
+  SELECT fruit.name,
+         fruit.adjectives,
+         fruit.id
+  FROM
+    (SELECT fruit.id AS id,
+            fruit.name AS name,
+            fruit.adjectives AS adjectives
+     FROM fruit AS fruit
+     LIMIT :param_1
+     OFFSET :param_2) AS fruit
+  LIMIT :param_3
+  '''
+# ---
+# name: test_always_load_column_hook[session-tracked-fruitsPaginated-async-psycopg_async_engine]
+  '''
+  SELECT fruit.name,
+         fruit.adjectives,
+         fruit.id
+  FROM
+    (SELECT fruit.id AS id,
+            fruit.name AS name,
+            fruit.adjectives AS adjectives
+     FROM fruit AS fruit
+     LIMIT :param_1
+     OFFSET :param_2) AS fruit
+  LIMIT :param_3
+  '''
+# ---
+# name: test_always_load_column_hook[session-tracked-fruitsPaginated-sync-psycopg_engine]
+  '''
+  SELECT fruit.name,
+         fruit.adjectives,
+         fruit.id
+  FROM
+    (SELECT fruit.id AS id,
+            fruit.name AS name,
+            fruit.adjectives AS adjectives
+     FROM fruit AS fruit
+     LIMIT :param_1
+     OFFSET :param_2) AS fruit
+  LIMIT :param_3
+  '''
+# ---
 # name: test_always_load_column_hook[session-tracked-sync-psycopg_engine]
   '''
   SELECT fruit.name,

--- a/tests/integration/__snapshots__/test_query_hooks.ambr
+++ b/tests/integration/__snapshots__/test_query_hooks.ambr
@@ -116,3 +116,72 @@
   WHERE fruit.name = :name_1
   '''
 # ---
+# name: test_load_columns_hook[session-tracked-fruits-async-asyncpg_engine]
+  '''
+  SELECT fruit.name,
+         fruit.adjectives,
+         fruit.id
+  FROM fruit AS fruit
+  '''
+# ---
+# name: test_load_columns_hook[session-tracked-fruits-async-psycopg_async_engine]
+  '''
+  SELECT fruit.name,
+         fruit.adjectives,
+         fruit.id
+  FROM fruit AS fruit
+  '''
+# ---
+# name: test_load_columns_hook[session-tracked-fruits-sync-psycopg_engine]
+  '''
+  SELECT fruit.name,
+         fruit.adjectives,
+         fruit.id
+  FROM fruit AS fruit
+  '''
+# ---
+# name: test_load_columns_hook[session-tracked-fruitsPaginated-async-asyncpg_engine]
+  '''
+  SELECT fruit.name,
+         fruit.adjectives,
+         fruit.id
+  FROM
+    (SELECT fruit.id AS id,
+            fruit.name AS name,
+            fruit.adjectives AS adjectives
+     FROM fruit AS fruit
+     LIMIT :param_1
+     OFFSET :param_2) AS fruit
+  LIMIT :param_3
+  '''
+# ---
+# name: test_load_columns_hook[session-tracked-fruitsPaginated-async-psycopg_async_engine]
+  '''
+  SELECT fruit.name,
+         fruit.adjectives,
+         fruit.id
+  FROM
+    (SELECT fruit.id AS id,
+            fruit.name AS name,
+            fruit.adjectives AS adjectives
+     FROM fruit AS fruit
+     LIMIT :param_1
+     OFFSET :param_2) AS fruit
+  LIMIT :param_3
+  '''
+# ---
+# name: test_load_columns_hook[session-tracked-fruitsPaginated-sync-psycopg_engine]
+  '''
+  SELECT fruit.name,
+         fruit.adjectives,
+         fruit.id
+  FROM
+    (SELECT fruit.id AS id,
+            fruit.name AS name,
+            fruit.adjectives AS adjectives
+     FROM fruit AS fruit
+     LIMIT :param_1
+     OFFSET :param_2) AS fruit
+  LIMIT :param_3
+  '''
+# ---

--- a/tests/integration/test_query_hooks.py
+++ b/tests/integration/test_query_hooks.py
@@ -50,7 +50,7 @@ def async_query() -> type[AsyncQuery]:
 
 @pytest.mark.parametrize("fruits_query", ["fruits", "fruitsPaginated"])
 @pytest.mark.snapshot
-async def test_always_load_column_hook(
+async def test_load_columns_hook(
     fruits_query: str,
     any_query: AnyQueryExecutor,
     raw_fruits: RawRecordData,
@@ -71,6 +71,16 @@ async def test_always_load_column_hook(
 
     assert query_tracker.query_count == 1
     assert query_tracker[0].statement_formatted == sql_snapshot
+
+
+@pytest.mark.parametrize("fruits_query", ["fruits", "fruitsPaginated"])
+async def test_empty_query_hook(fruits_query: str, any_query: AnyQueryExecutor) -> None:
+    result = await maybe_async(any_query(f"{{ {fruits_query} {{ emptyQueryHook }} }}"))
+
+    assert not result.errors
+    assert result.data
+    assert len(result.data[fruits_query]) == 5
+    assert result.data[fruits_query] == [{"emptyQueryHook": "success"} for _ in range(5)]
 
 
 @pytest.mark.snapshot

--- a/tests/integration/types.py
+++ b/tests/integration/types.py
@@ -52,6 +52,10 @@ class FruitTypeWithDescription:
     def description(self) -> str:
         return self.instance.description
 
+    @strawchemy.field(query_hook=QueryHook(load_columns=[]))
+    def empty_query_hook(self) -> str:
+        return "success"
+
 
 @strawchemy.type(Fruit, exclude={"color"}, query_hook=_user_fruit_filter)
 class FilteredFruitType: ...

--- a/tests/integration/types.py
+++ b/tests/integration/types.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from strawchemy import ModelInstance, QueryHook, Strawchemy
 from strawchemy.sqlalchemy.hook import QueryHookResult
 
@@ -9,11 +11,17 @@ from strawberry import Info
 
 from .models import Color, Fruit, SQLDataTypes, SQLDataTypesContainer, User
 
+if TYPE_CHECKING:
+    from strawchemy.sqlalchemy.typing import LoadMode
+
 strawchemy = Strawchemy()
 
 
 def _user_fruit_filter(
-    statement: Select[tuple[Fruit]], alias: AliasedClass[Fruit], info: Info
+    statement: Select[tuple[Fruit]],
+    alias: AliasedClass[Fruit],
+    mode: LoadMode,  # noqa: ARG001
+    info: Info,
 ) -> QueryHookResult[Fruit]:
     if info.context.role == "user":
         return QueryHookResult(statement=statement.where(alias.name == "Apple"))
@@ -40,7 +48,7 @@ class FruitType: ...
 class FruitTypeWithDescription:
     instance: ModelInstance[Fruit]
 
-    @strawchemy.field(query_hook=QueryHook(always_load=[Fruit.name, Fruit.adjectives]))
+    @strawchemy.field(query_hook=QueryHook(load_columns=[Fruit.name, Fruit.adjectives]))
     def description(self) -> str:
         return self.instance.description
 

--- a/tests/unit/mapping/test_types.py
+++ b/tests/unit/mapping/test_types.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 from strawchemy.exceptions import StrawchemyError
 from strawchemy.graphql.exceptions import InspectorError
+from strawchemy.sqlalchemy.exceptions import QueryHookError
 from strawchemy.strawberry.exceptions import StrawchemyFieldError
 from strawchemy.strawberry.scalars import Interval
 
@@ -132,6 +133,11 @@ def test_base_json_fails() -> None:
         match=("""Base SQLAlchemy JSON type is not supported. Use backend-specific json type instead."""),
     ):
         import_module("tests.unit.schemas.filters.filters_base_json")
+
+
+def test_query_hooks_load_columns_relationship_fails() -> None:
+    with pytest.raises(QueryHookError, match=("Relationships are not supported `load_columns`")):
+        import_module("tests.unit.schemas.query_hooks")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/schemas/query_hooks.py
+++ b/tests/unit/schemas/query_hooks.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from strawchemy import QueryHook, Strawchemy
+
+import strawberry
+from strawberry import auto
+from tests.unit.models import Fruit
+
+strawchemy = Strawchemy()
+
+
+@strawchemy.type(Fruit, query_hook=QueryHook(load_columns=[Fruit.color]))
+class FruitType:
+    family: auto
+
+
+@strawberry.type
+class Query:
+    fruits: list[FruitType] = strawchemy.field()


### PR DESCRIPTION
…umns

BREAKING CHANGE: - Change always_load -> load_columns\n- Only support column loading through load_columns

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

-

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Enforces that only column attributes can be loaded through `load_columns` in `QueryHook`, and renames `always_load` to `load_columns`.

Enhancements:
- Restricts the usage of `load_columns` to only column attributes, preventing the loading of relationships through this method.
- Renames `always_load` to `load_columns` for clarity and to better reflect its purpose.
- Improves the efficiency of data loading by ensuring only necessary columns are loaded, reducing database load and improving performance.
- Updates documentation and examples to reflect the change from `always_load` to `load_columns` and the restriction to column attributes only.
- Adds a check to prevent relationships from being used in `load_columns` and raises a `QueryHookError` if a relationship is found.
- Adds a new test case to verify that using relationships in `load_columns` raises a `QueryHookError`.
- Updates integration tests to use both paginated and non-paginated queries to test the `load_columns` functionality.