### PR TITLE
ci(coverage): use coverage combine

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,15 +94,28 @@ jobs:
       - name: Run tests
         run: mise run ci:test "${{ matrix.session.session }}"
 
-      - name: Upload test artifacts
+      - name: Rename coverage and junit files
+        run: |
+          mv coverage* coverage-${{ matrix.session.session }}.xml
+          mv junit* junit-${{ matrix.session.session }}.xml
+
+      - name: Upload coverage data
         uses: actions/upload-artifact@v4
-        id: upload-coverage-artifacts
+        id: upload-coverage-data
         if: ${{ always() }}
         with:
           name: coverage-${{ matrix.session.session }}
           path: |
-            coverage.xml
-            junit*.xml
+            coverage-${{ matrix.session.session }}.xml
+
+      - name: Upload test results data
+        uses: actions/upload-artifact@v4
+        id: upload-test-results-data
+        if: ${{ always() }}
+        with:
+          name: test-results-${{ matrix.session.session }}
+          path: |
+            junit-${{ matrix.session.session }}.xml
 
   upload-coverage:
     name: 🆙 Upload Coverage
@@ -112,6 +125,9 @@ jobs:
     steps:
       - name: Download test artifacts
         uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          merge-multiple: true
 
       - uses: actions/setup-python@v5
         with:
@@ -132,6 +148,20 @@ jobs:
           fail_ci_if_error: true
           verbose: true
 
+  upload-test-results:
+    name: 📊 Upload test results
+    needs: [tests, generate-jobs-tests]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        session: ${{ fromJson(needs.generate-jobs-tests.outputs.sessions) }}
+
+    steps:
+      - name: Download test artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: test-results-*
+
       - name: Upload test results to Codecov
         id: upload-test-results
         if: ${{ !cancelled() }}
@@ -139,6 +169,7 @@ jobs:
         with:
           name: ${{env.PROJECT_NAME}}-test-results
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: ${{ matrix.session.session }}
           verbose: true
 
   lint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Rename coverage and junit files
         run: |
-          mv .coverage* .coverage-${{ matrix.session.session }}.xml
+          mv .coverage* .coverage-${{ matrix.session.session }}
           mv junit* junit-${{ matrix.session.session }}.xml
 
       - name: Upload coverage data
@@ -105,7 +105,7 @@ jobs:
         if: ${{ always() }}
         with:
           name: coverage-${{ matrix.session.session }}
-          path: .coverage-${{ matrix.session.session }}.xml
+          path: .coverage-${{ matrix.session.session }}
           include-hidden-files: true
 
       - name: Upload test results data

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Rename coverage and junit files
         run: |
-          mv .coverage* .coverage-${{ matrix.session.session }}
+          mv .coverage* .coverage.${{ matrix.session.session }}
           mv junit* junit-${{ matrix.session.session }}.xml
 
       - name: Upload coverage data
@@ -105,7 +105,7 @@ jobs:
         if: ${{ always() }}
         with:
           name: coverage-${{ matrix.session.session }}
-          path: .coverage-${{ matrix.session.session }}
+          path: .coverage.${{ matrix.session.session }}
           include-hidden-files: true
 
       - name: Upload test results data

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Rename coverage and junit files
         run: |
-          mv .coverage* coverage-${{ matrix.session.session }}.xml
+          mv .coverage* .coverage-${{ matrix.session.session }}.xml
           mv junit* junit-${{ matrix.session.session }}.xml
 
       - name: Upload coverage data
@@ -105,8 +105,8 @@ jobs:
         if: ${{ always() }}
         with:
           name: coverage-${{ matrix.session.session }}
-          path: |
-            coverage-${{ matrix.session.session }}.xml
+          path: .coverage-${{ matrix.session.session }}.xml
+          include-hidden-files: true
 
       - name: Upload test results data
         uses: actions/upload-artifact@v4
@@ -114,8 +114,7 @@ jobs:
         if: ${{ always() }}
         with:
           name: test-results-${{ matrix.session.session }}
-          path: |
-            junit-${{ matrix.session.session }}.xml
+          path: junit-${{ matrix.session.session }}.xml
 
   upload-coverage:
     name: 🆙 Upload Coverage

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Rename coverage and junit files
         run: |
-          mv coverage* coverage-${{ matrix.session.session }}.xml
+          mv .coverage* coverage-${{ matrix.session.session }}.xml
           mv junit* junit-${{ matrix.session.session }}.xml
 
       - name: Upload coverage data

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,15 +108,20 @@ jobs:
     name: 🆙 Upload Coverage
     needs: [tests, generate-jobs-tests]
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        session: ${{ fromJson(needs.generate-jobs-tests.outputs.sessions) }}
 
     steps:
       - name: Download test artifacts
         uses: actions/download-artifact@v4
+
+      - uses: actions/setup-python@v5
         with:
-          pattern: coverage-${{ matrix.session.session }}
+          python-version: "3.12"
+
+      - name: Combine coverage files
+        run: |
+          python -Im pip install coverage covdefaults
+          python -Im coverage combine
+          python -Im coverage xml -i
 
       - name: Upload coverage to Codeocv
         id: upload-coverage
@@ -124,7 +129,6 @@ jobs:
         with:
           name: ${{env.PROJECT_NAME}}-tests
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: ${{ matrix.session.session }}
           fail_ci_if_error: true
           verbose: true
 
@@ -135,7 +139,6 @@ jobs:
         with:
           name: ${{env.PROJECT_NAME}}-test-results
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: ${{ matrix.session.session }}
           verbose: true
 
   lint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,6 +123,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Download test artifacts
         uses: actions/download-artifact@v4
         with:
@@ -157,6 +160,9 @@ jobs:
         session: ${{ fromJson(needs.generate-jobs-tests.outputs.sessions) }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Download test artifacts
         uses: actions/download-artifact@v4
         with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,9 @@ coverage:
         target: auto
         # This allows a 2% drop from the previous base commit coverage
         threshold: 2%
+    patch:
+      default:
+        target: auto
 flag_management:
   default_rules: # the rules that will be followed for any flag added, generally
     carryforward: true

--- a/mise.toml
+++ b/mise.toml
@@ -13,7 +13,7 @@ actionlint = "latest"
 [vars]
 local_pytest_options = "-n=6 -vv"
 pytest_coverage_options = "--cov-config=./pyproject.toml --cov=src --cov-report=html"
-ci_pytest_coverage_options = "--cov-config=./pyproject.toml --cov=src --cov-report=xml --junit-xml=./junit.xml -o junit_family=legacy"
+ci_pytest_coverage_options = "--cov-config=./pyproject.toml --cov=src --junit-xml=./junit.xml -o junit_family=legacy"
 nox_py13 = "uv run nox -r -p=3.13"
 
 cleanable_paths = '''{{

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ test = [
     "pytest-lazy-fixtures",
     "syrupy",
     "sqlparse",
+    "covdefaults",
 ]
 postgres = [
     "asyncpg>=0.29.0",
@@ -372,21 +373,14 @@ exclude = ["tests/fixtures.py", "tests/unit/schemas/mutations"]
 [tool.coverage.run]
 branch = true
 source = ["src"]
+plugins = ["covdefaults"]
 omit = ["*/tests/*"]
 parallel = true
 relative_files = true
 
 [tool.coverage.report]
-exclude_also = [
-    'def __repr__',
-    'pragma: no cover',
-    'if TYPE_CHECKING:',
-    'except ImportError as e:',
-    'except ImportError:',
-    '\.\.\.',
-    'raise NotImplementedError',
-    '@(abc\.)?abstractmethod',
-]
+exclude_also = ['def __repr__']
+fail_under = 50
 
 [tool.codespell]
 skip = '*.po,*.ts,./src/3rdParty,./src/Test'

--- a/uv.lock
+++ b/uv.lock
@@ -254,6 +254,18 @@ wheels = [
 ]
 
 [[package]]
+name = "covdefaults"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/ee/9a6f2611f72e4c5657ae5542a510cf4164d2c673687c0ea73bb1cbd85b4d/covdefaults-2.3.0.tar.gz", hash = "sha256:4e99f679f12d792bc62e5510fa3eb59546ed47bd569e36e4fddc4081c9c3ebf7", size = 4835 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/4c/823bc951445aa97e5a1b7e337690db3abf85212c8d138e170922e7916ac8/covdefaults-2.3.0-py2.py3-none-any.whl", hash = "sha256:2832961f6ffcfe4b57c338bc3418a3526f495c26fb9c54565409c5532f7c41be", size = 5144 },
+]
+
+[[package]]
 name = "coverage"
 version = "7.6.12"
 source = { registry = "https://pypi.org/simple" }
@@ -1626,6 +1638,7 @@ build = [
 dev = [
     { name = "asyncpg" },
     { name = "bump-my-version" },
+    { name = "covdefaults" },
     { name = "git-cliff" },
     { name = "nox", extra = ["uv"] },
     { name = "psycopg", extra = ["binary", "pool"] },
@@ -1659,6 +1672,7 @@ postgres = [
 ]
 test = [
     { name = "asyncpg" },
+    { name = "covdefaults" },
     { name = "nox", extra = ["uv"] },
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "psycopg2-binary" },
@@ -1693,6 +1707,7 @@ build = [
 dev = [
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "bump-my-version" },
+    { name = "covdefaults" },
     { name = "git-cliff" },
     { name = "git-cliff", specifier = ">=2.6.1" },
     { name = "nox", extras = ["uv"] },
@@ -1725,6 +1740,7 @@ postgres = [
 ]
 test = [
     { name = "asyncpg", specifier = ">=0.29.0" },
+    { name = "covdefaults" },
     { name = "nox", extras = ["uv"] },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.3" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

-

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Consolidates coverage reports from parallel test runs using `coverage combine` to improve coverage reporting accuracy. This change also updates the CI workflow to use Codecov for coverage reporting.

CI:
- Combines coverage files from parallel test runs into a single report.
- Updates the CI workflow to use Codecov for coverage reporting.
- Removes the session flag from the Codecov upload action in the CI workflow.

Tests:
- Adds `covdefaults` to the test dependencies.