### PR TITLE
feat(mapping): allow setting filter/order_by at the type level

### DIFF
--- a/src/strawchemy/graphql/dto.py
+++ b/src/strawchemy/graphql/dto.py
@@ -67,9 +67,7 @@ T = TypeVar("T")
 
 
 def _ensure_list(value: Any) -> Any:
-    if not isinstance(value, list):
-        return [value]
-    return value
+    return value if isinstance(value, list) else [value]
 
 
 class _HasValue(Protocol, Generic[ModelT, ModelFieldT]):
@@ -87,7 +85,7 @@ class StrawchemyDTOAttributes:
     __strawchemy_description__: ClassVar[str] = "GraphQL type"
     __strawchemy_field_map__: ClassVar[dict[DTOKey, GraphQLFieldDefinition[Any, Any]]] = {}
     __strawchemy_query_hook__: QueryHook[Any] | Sequence[QueryHook[Any]] | None = None
-    __strawchemy_is_root_aggregation_type__: bool = False
+    __strawchemy_is_root_aggregation_type__: ClassVar[bool] = False
 
 
 class _Key(Generic[T]):
@@ -480,7 +478,9 @@ class EnumDTO(DTOBase[Any], Enum):
     def field_definition(self) -> GraphQLFieldDefinition[Any, Any]: ...
 
 
-class MappedDataclassGraphQLDTO(StrawchemyDTOAttributes, MappedDataclassDTO[ModelT]): ...
+class MappedDataclassGraphQLDTO(StrawchemyDTOAttributes, MappedDataclassDTO[ModelT]):
+    __strawchemy_filter__: type[Any] | None = None
+    __strawchemy_order_by__: type[Any] | None = None
 
 
 class UnmappedDataclassGraphQLDTO(StrawchemyDTOAttributes, DataclassDTO[ModelT]): ...

--- a/src/strawchemy/mapper.py
+++ b/src/strawchemy/mapper.py
@@ -8,7 +8,7 @@ from strawchemy.dto.backend.dataclass import DataclassDTOBackend
 from strawchemy.dto.base import ModelFieldT, ModelT
 
 from .config import StrawchemyConfig
-from .graphql.dto import EnumDTO, MappedDataclassGraphQLDTO, OrderByEnum
+from .graphql.dto import BooleanFilterDTO, EnumDTO, MappedDataclassGraphQLDTO, OrderByDTO, OrderByEnum
 from .graphql.factory import DistinctOnFieldsDTOFactory
 from .strawberry import StrawchemyField
 from .strawberry.factory import (
@@ -28,10 +28,10 @@ if TYPE_CHECKING:
     from strawberry import BasePermission
     from strawberry.extensions.field_extension import FieldExtension
     from strawberry.types.field import _RESOLVER_TYPE
-    from strawchemy.sqlalchemy.hook import QueryHook
 
+    from .sqlalchemy.hook import QueryHook
     from .sqlalchemy.typing import QueryHookCallable
-    from .strawberry.typing import FilterStatementCallable
+    from .strawberry.typing import FilterStatementCallable, StrawchemyTypeFromPydantic
     from .typing import AnyRepository
 
 
@@ -82,8 +82,8 @@ class Strawchemy(Generic[ModelT, ModelFieldT]):
         self,
         resolver: _RESOLVER_TYPE[Any],
         *,
-        filter_input: type[Any] | None = None,
-        order_by: type[Any] | None = None,
+        filter_input: type[StrawchemyTypeFromPydantic[BooleanFilterDTO[T, ModelFieldT]]] | None = None,
+        order_by: type[StrawchemyTypeFromPydantic[OrderByDTO[T, ModelFieldT]]] | None = None,
         distinct_on: type[EnumDTO] | None = None,
         pagination: bool | DefaultOffsetPagination | None = None,
         id_field_name: str | None = None,
@@ -109,8 +109,8 @@ class Strawchemy(Generic[ModelT, ModelFieldT]):
     def field(
         self,
         *,
-        filter_input: type[Any] | None = None,
-        order_by: type[Any] | None = None,
+        filter_input: type[StrawchemyTypeFromPydantic[BooleanFilterDTO[T, ModelFieldT]]] | None = None,
+        order_by: type[StrawchemyTypeFromPydantic[OrderByDTO[T, ModelFieldT]]] | None = None,
         distinct_on: type[EnumDTO] | None = None,
         pagination: bool | DefaultOffsetPagination | None = None,
         id_field_name: str | None = None,
@@ -136,8 +136,8 @@ class Strawchemy(Generic[ModelT, ModelFieldT]):
         self,
         resolver: _RESOLVER_TYPE[Any] | None = None,
         *,
-        filter_input: type[Any] | None = None,
-        order_by: type[Any] | None = None,
+        filter_input: type[StrawchemyTypeFromPydantic[BooleanFilterDTO[T, ModelFieldT]]] | None = None,
+        order_by: type[StrawchemyTypeFromPydantic[OrderByDTO[T, ModelFieldT]]] | None = None,
         distinct_on: type[EnumDTO] | None = None,
         pagination: bool | DefaultOffsetPagination | None = None,
         id_field_name: str | None = None,

--- a/src/strawchemy/strawberry/_registry.py
+++ b/src/strawchemy/strawberry/_registry.py
@@ -14,7 +14,7 @@ from strawberry.types.base import StrawberryContainer
 from strawberry.types.field import StrawberryField
 from strawchemy.strawberry import pydantic as strawberry_pydantic
 
-from ._utils import strawberry_contained_type, strawberry_type_from_pydantic
+from ._utils import strawberry_contained_type, strawchemy_type_from_pydantic
 
 try:
     from strawchemy.graphql.filters.geo import GeoComparison
@@ -244,7 +244,7 @@ class StrawberryRegistry:
     ) -> type[StrawberryTypeFromPydantic[PydanticModel]]:
         self._check_conflicts(type_info)
         strawberry_attr = "_strawberry_input_type" if type_info.graphql_type == "input" else "_strawberry_type"
-        if existing := strawberry_type_from_pydantic(pydantic_type):
+        if existing := strawchemy_type_from_pydantic(pydantic_type):
             return existing
         if existing := self._get(type_info):
             setattr(pydantic_type, strawberry_attr, existing)

--- a/src/strawchemy/strawberry/_utils.py
+++ b/src/strawchemy/strawberry/_utils.py
@@ -10,13 +10,14 @@ from strawberry.types.lazy_type import LazyType
 if TYPE_CHECKING:
     from strawberry import Info
     from strawberry.experimental.pydantic.conversion_types import PydanticModel, StrawberryTypeFromPydantic
+    from strawchemy.strawberry.typing import StrawchemyTypeFromPydantic
 
 
 __all__ = (
     "default_session_getter",
     "dto_model_from_type",
     "pydantic_from_strawberry_type",
-    "strawberry_type_from_pydantic",
+    "strawchemy_type_from_pydantic",
 )
 
 
@@ -29,26 +30,26 @@ def pydantic_from_strawberry_type(type_: type[StrawberryTypeFromPydantic[Pydanti
 
 
 @overload
-def strawberry_type_from_pydantic(
+def strawchemy_type_from_pydantic(
     type_: type[PydanticModel], strict: Literal[False]
-) -> type[StrawberryTypeFromPydantic[PydanticModel]] | None: ...
+) -> type[StrawchemyTypeFromPydantic[PydanticModel]] | None: ...
 
 
 @overload
-def strawberry_type_from_pydantic(
+def strawchemy_type_from_pydantic(
     type_: type[PydanticModel], strict: Literal[True]
-) -> type[StrawberryTypeFromPydantic[PydanticModel]]: ...
+) -> type[StrawchemyTypeFromPydantic[PydanticModel]]: ...
 
 
 @overload
-def strawberry_type_from_pydantic(
+def strawchemy_type_from_pydantic(
     type_: type[PydanticModel], strict: bool = False
-) -> type[StrawberryTypeFromPydantic[PydanticModel]] | None: ...
+) -> type[StrawchemyTypeFromPydantic[PydanticModel]] | None: ...
 
 
-def strawberry_type_from_pydantic(
+def strawchemy_type_from_pydantic(
     type_: type[PydanticModel], strict: bool = False
-) -> type[StrawberryTypeFromPydantic[PydanticModel]] | None:
+) -> type[StrawchemyTypeFromPydantic[PydanticModel]] | None:
     try:
         return get_strawberry_type_from_model(type_)
     except UnregisteredTypeException as error:

--- a/src/strawchemy/strawberry/repository/_async.py
+++ b/src/strawchemy/strawberry/repository/_async.py
@@ -41,7 +41,11 @@ if TYPE_CHECKING:
     from strawberry.types.field import StrawberryField
     from strawchemy.sqlalchemy.hook import QueryHook
     from strawchemy.sqlalchemy.typing import AnyAsyncSession
-    from strawchemy.strawberry.typing import AsyncSessionGetter, StrawchemyTypeWithStrawberryObjectDefinition
+    from strawchemy.strawberry.typing import (
+        AsyncSessionGetter,
+        StrawchemyTypeFromPydantic,
+        StrawchemyTypeWithStrawberryObjectDefinition,
+    )
 
 __all__ = ("StrawchemyAsyncRepository",)
 
@@ -172,8 +176,8 @@ class StrawchemyAsyncRepository(Generic[T]):
 
     async def get_one_or_none(
         self,
-        filter_input: StrawberryTypeFromPydantic[BooleanFilterDTO[Any, Any]] | None = None,
-        order_by: list[StrawberryTypeFromPydantic[OrderByDTO[Any, Any]]] | None = None,
+        filter_input: StrawchemyTypeFromPydantic[BooleanFilterDTO[Any, Any]] | None = None,
+        order_by: list[StrawchemyTypeFromPydantic[OrderByDTO[Any, Any]]] | None = None,
         distinct_on: list[EnumDTO] | None = None,
         limit: int | None = None,
         offset: int | None = None,
@@ -193,8 +197,8 @@ class StrawchemyAsyncRepository(Generic[T]):
 
     async def get_one(
         self,
-        filter_input: StrawberryTypeFromPydantic[BooleanFilterDTO[Any, Any]] | None = None,
-        order_by: list[StrawberryTypeFromPydantic[OrderByDTO[Any, Any]]] | None = None,
+        filter_input: StrawchemyTypeFromPydantic[BooleanFilterDTO[Any, Any]] | None = None,
+        order_by: list[StrawchemyTypeFromPydantic[OrderByDTO[Any, Any]]] | None = None,
         distinct_on: list[EnumDTO] | None = None,
         limit: int | None = None,
         offset: int | None = None,
@@ -228,8 +232,8 @@ class StrawchemyAsyncRepository(Generic[T]):
 
     async def list(
         self,
-        filter_input: StrawberryTypeFromPydantic[BooleanFilterDTO[Any, Any]] | None = None,
-        order_by: list[StrawberryTypeFromPydantic[OrderByDTO[Any, Any]]] | None = None,
+        filter_input: StrawchemyTypeFromPydantic[BooleanFilterDTO[Any, Any]] | None = None,
+        order_by: list[StrawchemyTypeFromPydantic[OrderByDTO[Any, Any]]] | None = None,
         distinct_on: list[EnumDTO] | None = None,
         limit: int | None = None,
         offset: int | None = None,

--- a/src/strawchemy/strawberry/repository/_sync.py
+++ b/src/strawchemy/strawberry/repository/_sync.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
     from strawchemy.sqlalchemy.hook import QueryHook
     from strawchemy.sqlalchemy.typing import AnySyncSession
     from strawchemy.strawberry.typing import (
+        StrawchemyTypeFromPydantic,
         StrawchemyTypeWithStrawberryObjectDefinition,
         SyncSessionGetter,
     )
@@ -177,8 +178,8 @@ class StrawchemySyncRepository(Generic[T]):
 
     def get_one_or_none(
         self,
-        filter_input: StrawberryTypeFromPydantic[BooleanFilterDTO[Any, Any]] | None = None,
-        order_by: list[StrawberryTypeFromPydantic[OrderByDTO[Any, Any]]] | None = None,
+        filter_input: StrawchemyTypeFromPydantic[BooleanFilterDTO[Any, Any]] | None = None,
+        order_by: list[StrawchemyTypeFromPydantic[OrderByDTO[Any, Any]]] | None = None,
         distinct_on: list[EnumDTO] | None = None,
         limit: int | None = None,
         offset: int | None = None,
@@ -198,8 +199,8 @@ class StrawchemySyncRepository(Generic[T]):
 
     def get_one(
         self,
-        filter_input: StrawberryTypeFromPydantic[BooleanFilterDTO[Any, Any]] | None = None,
-        order_by: list[StrawberryTypeFromPydantic[OrderByDTO[Any, Any]]] | None = None,
+        filter_input: StrawchemyTypeFromPydantic[BooleanFilterDTO[Any, Any]] | None = None,
+        order_by: list[StrawchemyTypeFromPydantic[OrderByDTO[Any, Any]]] | None = None,
         distinct_on: list[EnumDTO] | None = None,
         limit: int | None = None,
         offset: int | None = None,
@@ -233,8 +234,8 @@ class StrawchemySyncRepository(Generic[T]):
 
     def list(
         self,
-        filter_input: StrawberryTypeFromPydantic[BooleanFilterDTO[Any, Any]] | None = None,
-        order_by: list[StrawberryTypeFromPydantic[OrderByDTO[Any, Any]]] | None = None,
+        filter_input: StrawchemyTypeFromPydantic[BooleanFilterDTO[Any, Any]] | None = None,
+        order_by: list[StrawchemyTypeFromPydantic[OrderByDTO[Any, Any]]] | None = None,
         distinct_on: list[EnumDTO] | None = None,
         limit: int | None = None,
         offset: int | None = None,

--- a/src/strawchemy/strawberry/typing.py
+++ b/src/strawchemy/strawberry/typing.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
 
 __all__ = (
     "AnySessionGetter",
-    "AnyStrawchemyType",
     "AsyncSessionGetter",
     "FilterStatementCallable",
     "StrawchemyTypeFromPydantic",
@@ -34,6 +33,3 @@ class StrawchemyTypeWithStrawberryObjectDefinition(StrawchemyDTOAttributes, With
 
 
 class StrawchemyTypeFromPydantic(StrawchemyDTOAttributes, StrawberryTypeFromPydantic[PydanticModel]): ...
-
-
-AnyStrawchemyType: TypeAlias = "StrawchemyTypeFromPydantic[Any] | StrawchemyTypeWithStrawberryObjectDefinition"

--- a/src/strawchemy/strawberry/typing.py
+++ b/src/strawchemy/strawberry/typing.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
+from strawberry.experimental.pydantic.conversion_types import PydanticModel, StrawberryTypeFromPydantic
 from strawberry.types.base import WithStrawberryObjectDefinition
 from strawchemy.graphql.dto import StrawchemyDTOAttributes
 
@@ -14,8 +15,10 @@ if TYPE_CHECKING:
 
 __all__ = (
     "AnySessionGetter",
+    "AnyStrawchemyType",
     "AsyncSessionGetter",
     "FilterStatementCallable",
+    "StrawchemyTypeFromPydantic",
     "StrawchemyTypeWithStrawberryObjectDefinition",
     "SyncSessionGetter",
 )
@@ -28,3 +31,9 @@ FilterStatementCallable: TypeAlias = "Callable[[Info[Any, Any]], Select[tuple[An
 
 
 class StrawchemyTypeWithStrawberryObjectDefinition(StrawchemyDTOAttributes, WithStrawberryObjectDefinition): ...
+
+
+class StrawchemyTypeFromPydantic(StrawchemyDTOAttributes, StrawberryTypeFromPydantic[PydanticModel]): ...
+
+
+AnyStrawchemyType: TypeAlias = "StrawchemyTypeFromPydantic[Any] | StrawchemyTypeWithStrawberryObjectDefinition"

--- a/tests/unit/mapping/__snapshots__/test_types/test_schemas[type_filter].gql
+++ b/tests/unit/mapping/__snapshots__/test_types/test_schemas[type_filter].gql
@@ -1,0 +1,284 @@
+# serializer version: 1
+# name: test_schemas[type_filter]
+  '''
+  """
+  Boolean expression to compare fields of type Boolean. All fields are combined with logical 'AND'
+  """
+  input BooleanComparison {
+    eq: Boolean
+    neq: Boolean
+    isNull: Boolean
+    in: [Boolean!]
+    nin: [Boolean!]
+  }
+  
+  """Date (isoformat)"""
+  scalar Date
+  
+  """
+  Boolean expression to compare fields of type Date. All fields are combined with logical 'AND'
+  """
+  input DateComparison {
+    eq: Date
+    neq: Date
+    isNull: Boolean
+    in: [Date!]
+    nin: [Date!]
+    gt: Date
+    gte: Date
+    lt: Date
+    lte: Date
+    year: IntComparison
+    month: IntComparison
+    day: IntComparison
+    weekDay: IntComparison
+    week: IntComparison
+    quarter: IntComparison
+    isoYear: IntComparison
+    isoWeekDay: IntComparison
+  }
+  
+  """Date with time (isoformat)"""
+  scalar DateTime
+  
+  """
+  Boolean expression to compare fields of type DateTime. All fields are combined with logical 'AND'
+  """
+  input DateTimeComparison {
+    eq: DateTime
+    neq: DateTime
+    isNull: Boolean
+    in: [DateTime!]
+    nin: [DateTime!]
+    gt: DateTime
+    gte: DateTime
+    lt: DateTime
+    lte: DateTime
+    hour: IntComparison
+    minute: IntComparison
+    second: IntComparison
+    year: IntComparison
+    month: IntComparison
+    day: IntComparison
+    weekDay: IntComparison
+    week: IntComparison
+    quarter: IntComparison
+    isoYear: IntComparison
+    isoWeekDay: IntComparison
+  }
+  
+  """Decimal (fixed-point)"""
+  scalar Decimal
+  
+  """
+  Boolean expression to compare fields of type Decimal. All fields are combined with logical 'AND'
+  """
+  input DecimalComparison {
+    eq: Decimal
+    neq: Decimal
+    isNull: Boolean
+    in: [Decimal!]
+    nin: [Decimal!]
+    gt: Decimal
+    gte: Decimal
+    lt: Decimal
+    lte: Decimal
+  }
+  
+  """
+  Boolean expression to compare fields of type Float. All fields are combined with logical 'AND'
+  """
+  input FloatComparison {
+    eq: Float
+    neq: Float
+    isNull: Boolean
+    in: [Float!]
+    nin: [Float!]
+    gt: Float
+    gte: Float
+    lt: Float
+    lte: Float
+  }
+  
+  """
+  Boolean expression to compare fields of type Int. All fields are combined with logical 'AND'
+  """
+  input IntComparison {
+    eq: Int
+    neq: Int
+    isNull: Boolean
+    in: [Int!]
+    nin: [Int!]
+    gt: Int
+    gte: Int
+    lt: Int
+    lte: Int
+  }
+  
+  """
+  The `Interval` scalar type represents a duration of time as specified by [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations).
+  """
+  scalar Interval @specifiedBy(url: "https://en.wikipedia.org/wiki/ISO_8601#Durations")
+  
+  """
+  Boolean expression to compare fields of type Interval. All fields are combined with logical 'AND'
+  """
+  input IntervalComparison {
+    eq: Interval
+    neq: Interval
+    isNull: Boolean
+    in: [Interval!]
+    nin: [Interval!]
+    gt: Interval
+    gte: Interval
+    lt: Interval
+    lte: Interval
+    days: FloatComparison
+    hours: FloatComparison
+    minutes: FloatComparison
+    seconds: FloatComparison
+  }
+  
+  """
+  The `JSON` scalar type represents JSON values as specified by [ECMA-404](https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf).
+  """
+  scalar JSON @specifiedBy(url: "https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf")
+  
+  """
+  Boolean expression to compare fields of type JSON. All fields are combined with logical 'AND'
+  """
+  input JSONComparison {
+    eq: JSON
+    neq: JSON
+    isNull: Boolean
+    in: [JSON!]
+    nin: [JSON!]
+    contains: JSON
+    containedIn: JSON
+    hasKey: String
+    hasKeyAll: [String!]
+    hasKeyAny: [String!]
+  }
+  
+  type Query {
+    """Fetch objects from the SQLDataTypesType collection"""
+    sqlDataTypes(filter: SQLDataTypesFilter = null): [SQLDataTypesType!]!
+  }
+  
+  """
+  Boolean expression to compare fields. All fields are combined with logical 'AND'.
+  """
+  input SQLDataTypesFilter {
+    _and: [SQLDataTypesFilter!]
+    _or: [SQLDataTypesFilter!]
+    _not: SQLDataTypesFilter
+    id: UUIDComparison
+    dateCol: DateComparison
+    timeCol: TimeComparison
+    timeDeltaCol: IntervalComparison
+    datetimeCol: DateTimeComparison
+    strCol: StringComparison
+    intCol: IntComparison
+    floatCol: FloatComparison
+    decimalCol: DecimalComparison
+    boolCol: BooleanComparison
+    uuidCol: UUIDComparison
+    dictCol: JSONComparison
+    arrayStrCol: StringArrayComparison
+  }
+  
+  """GraphQL type"""
+  type SQLDataTypesType {
+    id: UUID!
+    dateCol: Date!
+    timeCol: Time!
+    timeDeltaCol: Interval!
+    datetimeCol: DateTime!
+    strCol: String!
+    intCol: Int!
+    floatCol: Float!
+    decimalCol: Decimal!
+    boolCol: Boolean!
+    uuidCol: UUID!
+    dictCol: JSON!
+    arrayStrCol: [String!]!
+  }
+  
+  """
+  Boolean expression to compare array fields of type String. All fields are combined with logical 'AND'
+  """
+  input StringArrayComparison {
+    eq: String
+    neq: String
+    isNull: Boolean
+    in: [String!]
+    nin: [String!]
+    contains: [String!]
+    containedIn: [String!]
+    overlap: [String!]
+  }
+  
+  """
+  Boolean expression to compare fields of type String. All fields are combined with logical 'AND'
+  """
+  input StringComparison {
+    eq: String
+    neq: String
+    isNull: Boolean
+    in: [String!]
+    nin: [String!]
+    gt: String
+    gte: String
+    lt: String
+    lte: String
+    like: String
+    nlike: String
+    ilike: String
+    nilike: String
+    regexp: String
+    iregexp: String
+    nregexp: String
+    inregexp: String
+    startswith: String
+    endswith: String
+    contains: String
+    istartswith: String
+    iendswith: String
+    icontains: String
+  }
+  
+  """Time (isoformat)"""
+  scalar Time
+  
+  """
+  Boolean expression to compare fields of type Time. All fields are combined with logical 'AND'
+  """
+  input TimeComparison {
+    eq: Time
+    neq: Time
+    isNull: Boolean
+    in: [Time!]
+    nin: [Time!]
+    gt: Time
+    gte: Time
+    lt: Time
+    lte: Time
+    hour: IntComparison
+    minute: IntComparison
+    second: IntComparison
+  }
+  
+  scalar UUID
+  
+  """
+  Boolean expression to compare fields of type UUID. All fields are combined with logical 'AND'
+  """
+  input UUIDComparison {
+    eq: UUID
+    neq: UUID
+    isNull: Boolean
+    in: [UUID!]
+    nin: [UUID!]
+  }
+  '''
+# ---

--- a/tests/unit/mapping/__snapshots__/test_types/test_schemas[type_order_by].gql
+++ b/tests/unit/mapping/__snapshots__/test_types/test_schemas[type_order_by].gql
@@ -1,0 +1,76 @@
+# serializer version: 1
+# name: test_schemas[type_order_by]
+  '''
+  """Date (isoformat)"""
+  scalar Date
+  
+  """Date with time (isoformat)"""
+  scalar DateTime
+  
+  """Decimal (fixed-point)"""
+  scalar Decimal
+  
+  """
+  The `Interval` scalar type represents a duration of time as specified by [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations).
+  """
+  scalar Interval @specifiedBy(url: "https://en.wikipedia.org/wiki/ISO_8601#Durations")
+  
+  """
+  The `JSON` scalar type represents JSON values as specified by [ECMA-404](https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf).
+  """
+  scalar JSON @specifiedBy(url: "https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf")
+  
+  enum OrderByEnum {
+    ASC
+    ASC_NULLS_FIRST
+    ASC_NULLS_LAST
+    DESC
+    DESC_NULLS_FIRST
+    DESC_NULLS_LAST
+  }
+  
+  type Query {
+    """Fetch objects from the SQLDataTypesType collection"""
+    sqlDataTypes(orderBy: [SQLDataTypesOrderBy!] = null): [SQLDataTypesType!]!
+  }
+  
+  """Ordering options"""
+  input SQLDataTypesOrderBy {
+    id: OrderByEnum
+    dateCol: OrderByEnum
+    timeCol: OrderByEnum
+    timeDeltaCol: OrderByEnum
+    datetimeCol: OrderByEnum
+    strCol: OrderByEnum
+    intCol: OrderByEnum
+    floatCol: OrderByEnum
+    decimalCol: OrderByEnum
+    boolCol: OrderByEnum
+    uuidCol: OrderByEnum
+    dictCol: OrderByEnum
+    arrayStrCol: OrderByEnum
+  }
+  
+  """GraphQL type"""
+  type SQLDataTypesType {
+    id: UUID!
+    dateCol: Date!
+    timeCol: Time!
+    timeDeltaCol: Interval!
+    datetimeCol: DateTime!
+    strCol: String!
+    intCol: Int!
+    floatCol: Float!
+    decimalCol: Decimal!
+    boolCol: Boolean!
+    uuidCol: UUID!
+    dictCol: JSON!
+    arrayStrCol: [String!]!
+  }
+  
+  """Time (isoformat)"""
+  scalar Time
+  
+  scalar UUID
+  '''
+# ---

--- a/tests/unit/mapping/test_types.py
+++ b/tests/unit/mapping/test_types.py
@@ -168,6 +168,8 @@ def test_query_hooks_load_columns_relationship_fails() -> None:
         pytest.param("enums.Query", id="enums"),
         pytest.param("filters.filters.Query", id="filters"),
         pytest.param("filters.filters_aggregation.Query", id="aggregation_filters"),
+        pytest.param("filters.type_filter.Query", id="type_filter"),
+        pytest.param("order.type_order_by.Query", id="type_order_by"),
         pytest.param("aggregations.root_aggregations.Query", id="root_aggregations"),
     ],
 )
@@ -210,3 +212,23 @@ def test_mutation_schemas(path: str, graphql_snapshot: SnapshotAssertion) -> Non
 
     schema = strawberry.Schema(query=Query, mutation=mutation_class, scalar_overrides=SCALAR_OVERRIDES)
     assert textwrap.dedent(str(schema)).strip() == graphql_snapshot
+
+
+def test_field_filter_equals_type_filter() -> None:
+    from tests.unit.schemas.filters.filters import Query as FieldFilterQuery
+    from tests.unit.schemas.filters.type_filter import Query as TypeFilterQuery
+
+    field_filter_schema = strawberry.Schema(query=FieldFilterQuery, scalar_overrides=SCALAR_OVERRIDES)
+    type_filter_schema = strawberry.Schema(query=TypeFilterQuery, scalar_overrides=SCALAR_OVERRIDES)
+
+    assert textwrap.dedent(str(field_filter_schema)).strip() == textwrap.dedent(str(type_filter_schema)).strip()
+
+
+def test_field_order_by_equals_type_order_by() -> None:
+    from tests.unit.schemas.order.field_order_by import Query as FieldOrderQuery
+    from tests.unit.schemas.order.type_order_by import Query as TypeOrderQuery
+
+    field_filter_schema = strawberry.Schema(query=FieldOrderQuery, scalar_overrides=SCALAR_OVERRIDES)
+    type_filter_schema = strawberry.Schema(query=TypeOrderQuery, scalar_overrides=SCALAR_OVERRIDES)
+
+    assert textwrap.dedent(str(field_filter_schema)).strip() == textwrap.dedent(str(type_filter_schema)).strip()

--- a/tests/unit/schemas/filters/type_filter.py
+++ b/tests/unit/schemas/filters/type_filter.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from strawchemy import Strawchemy
+
+import strawberry
+from tests.unit.models import SQLDataTypes
+
+strawchemy = Strawchemy()
+
+
+@strawchemy.filter_input(SQLDataTypes, include="all")
+class SQLDataTypesFilter: ...
+
+
+@strawchemy.type(SQLDataTypes, include="all", filter_input=SQLDataTypesFilter)
+class SQLDataTypesType: ...
+
+
+@strawberry.type
+class Query:
+    sql_data_types: list[SQLDataTypesType] = strawchemy.field()

--- a/tests/unit/schemas/order/field_order_by.py
+++ b/tests/unit/schemas/order/field_order_by.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from strawchemy import Strawchemy
+
+import strawberry
+from tests.unit.models import SQLDataTypes
+
+strawchemy = Strawchemy()
+
+
+@strawchemy.order_by_input(SQLDataTypes, include="all")
+class SQLDataTypesOrderBy: ...
+
+
+@strawchemy.type(SQLDataTypes, include="all")
+class SQLDataTypesType: ...
+
+
+@strawberry.type
+class Query:
+    sql_data_types: list[SQLDataTypesType] = strawchemy.field(order_by=SQLDataTypesOrderBy)

--- a/tests/unit/schemas/order/type_order_by.py
+++ b/tests/unit/schemas/order/type_order_by.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from strawchemy import Strawchemy
+
+import strawberry
+from tests.unit.models import SQLDataTypes
+
+strawchemy = Strawchemy()
+
+
+@strawchemy.order_by_input(SQLDataTypes, include="all")
+class SQLDataTypesOrderBy: ...
+
+
+@strawchemy.type(SQLDataTypes, include="all", order_by=SQLDataTypesOrderBy)
+class SQLDataTypesType: ...
+
+
+@strawberry.type
+class Query:
+    sql_data_types: list[SQLDataTypesType] = strawchemy.field()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

-

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Allows setting filter and order_by at the type level using the @strawchemy.type decorator, simplifying the process of defining GraphQL types with filtering and ordering capabilities.

Enhancements:
- Introduces the ability to define filter and order_by at the type level, reducing code duplication and improving maintainability.
- Adds cached properties for filter and order_by to retrieve them from the inner type if not explicitly provided.
- Updates the factory to allow specifying filter and order_by inputs when creating a type.
- Updates the repository to use the filter and order_by types defined at the type level.