### PR TITLE
feat(input): track relationship changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,14 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Natural Language :: English",
   "Operating System :: OS Independent",
+  "Programming Language :: Python",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python",
-  "Topic :: Database :: Database Engines/Servers",
   "Topic :: Database",
+  "Topic :: Database :: Database Engines/Servers",
   "Topic :: Software Development",
   "Typing :: Typed",
 ]
@@ -390,3 +390,4 @@ min_confidence = 100
 paths = ["src", "tests"]
 sort_by_size = true
 exclude = ["tests/fixtures.py", "tests/unit/schemas/mutations"]
+ignore_names = ["target"]

--- a/src/strawchemy/__init__.py
+++ b/src/strawchemy/__init__.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from .graphql.exceptions import InputValidationError
-from .graphql.mutation import Input
+from .exceptions import InputValidationError
+from .input import Input
 from .mapper import Strawchemy
 from .sqlalchemy.hook import QueryHook
 from .strawberry import ModelInstance

--- a/src/strawchemy/exceptions.py
+++ b/src/strawchemy/exceptions.py
@@ -1,6 +1,16 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pydantic import ValidationError
+
 __all__ = ("StrawchemyError",)
 
 
 class StrawchemyError(Exception): ...
+
+
+class InputValidationError(Exception):
+    def __init__(self, pydantic_error: ValidationError) -> None:
+        self.pydantic_error = pydantic_error

--- a/src/strawchemy/graphql/exceptions.py
+++ b/src/strawchemy/graphql/exceptions.py
@@ -1,16 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from pydantic import ValidationError
-
-__all__ = ("InputValidationError", "InspectorError")
+__all__ = ("InspectorError",)
 
 
 class InspectorError(Exception): ...
-
-
-class InputValidationError(Exception):
-    def __init__(self, pydantic_error: ValidationError) -> None:
-        self.pydantic_error = pydantic_error

--- a/src/strawchemy/graphql/mutation.py
+++ b/src/strawchemy/graphql/mutation.py
@@ -1,27 +1,12 @@
 from __future__ import annotations
 
-import dataclasses
-from collections.abc import Sequence
-from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Any, Generic, Literal, Self, TypeAlias, TypeVar, override
+from typing import Any, Generic, TypeVar, override
 
-from pydantic import ValidationError
-
-from strawchemy.dto.base import DTOFieldDefinition, MappedDTO, ModelFieldT, ModelT, ToMappedProtocol, VisitorProtocol
+from strawchemy.dto.base import MappedDTO, ToMappedProtocol, VisitorProtocol
 from strawchemy.dto.types import DTO_UNSET, DTOUnsetType
 
-from .exceptions import InputValidationError
-
-if TYPE_CHECKING:
-    from collections.abc import Iterable
-
-    from strawchemy.dto.backend.pydantic import MappedPydanticDTO
-
-
 __all__ = (
-    "Input",
-    "LevelInput",
     "RelationType",
     "RequiredToManyUpdateInputMixin",
     "RequiredToOneInputMixin",
@@ -31,9 +16,7 @@ __all__ = (
 )
 
 T = TypeVar("T", bound=MappedDTO[Any])
-InputModel = TypeVar("InputModel")
 RelationInputT = TypeVar("RelationInputT", bound=MappedDTO[Any])
-RelationInputType: TypeAlias = Literal["set", "create", "add", "remove"]
 
 
 class RelationType(Enum):
@@ -112,164 +95,3 @@ class ToManyUpdateInputMixin(RequiredToManyUpdateInputMixin[T, RelationInputT]):
             msg = "You cannot use `set` with `create`, `add` or `remove` in a -to-many relation input"
             raise ValueError(msg)
         return super().to_mapped(visitor, level=level, override=override)
-
-
-@dataclass
-class _UnboundRelationInput(Generic[ModelT, ModelFieldT]):
-    field: DTOFieldDefinition[ModelT, ModelFieldT]
-    relation_type: RelationType
-    set: list[ModelT] | None = dataclasses.field(default_factory=list)
-    add: list[ModelT] = dataclasses.field(default_factory=list)
-    remove: list[ModelT] = dataclasses.field(default_factory=list)
-    create: list[ModelT] = dataclasses.field(default_factory=list)
-    input_index: int = -1
-    level: int = 0
-
-
-@dataclass(kw_only=True)
-class _RelationInput(_UnboundRelationInput[ModelT, ModelFieldT], Generic[ModelT, ModelFieldT]):
-    parent: ModelT
-
-    @classmethod
-    def from_unbound(cls, unbound: _UnboundRelationInput[ModelT, ModelFieldT], model: ModelT) -> Self:
-        return cls(
-            parent=model,
-            field=unbound.field,
-            set=unbound.set,
-            add=unbound.add,
-            remove=unbound.remove,
-            relation_type=unbound.relation_type,
-            create=unbound.create,
-            input_index=unbound.input_index,
-            level=unbound.level,
-        )
-
-
-@dataclass
-class _InputVisitor(VisitorProtocol, Generic[ModelT, ModelFieldT]):
-    input_data: Input[ModelT, ModelFieldT, Any]
-
-    current_relations: list[_UnboundRelationInput[ModelT, ModelFieldT]] = dataclasses.field(default_factory=list)
-
-    @override
-    def field_value(self, parent: ToMappedProtocol, field: DTOFieldDefinition[Any, Any], value: Any, level: int) -> Any:
-        field_value = getattr(parent, field.model_field_name)
-        add, remove, create = [], [], []
-        set_: list[Any] | None = []
-        relation_type = RelationType.TO_MANY
-        if isinstance(field_value, ToOneInputMixin):
-            relation_type = RelationType.TO_ONE
-            if field_value.set is None:
-                set_ = None
-            elif field_value.set:
-                set_ = [field_value.set.to_mapped()]
-        elif isinstance(field_value, ToManyUpdateInputMixin | ToManyCreateInputMixin):
-            if field_value.set:
-                set_ = [dto.to_mapped() for dto in field_value.set]
-            if field_value.add:
-                add = [dto.to_mapped() for dto in field_value.add]
-        if isinstance(field_value, ToManyUpdateInputMixin) and field_value.remove:
-            remove = [dto.to_mapped() for dto in field_value.remove]
-        if (
-            isinstance(field_value, ToOneInputMixin | ToManyUpdateInputMixin | ToManyCreateInputMixin)
-            and field_value.create
-        ):
-            create = value if isinstance(value, list) else [value]
-        if set_ is None or set_ or add or remove or create:
-            self.current_relations.append(
-                _UnboundRelationInput(
-                    field=field,
-                    relation_type=relation_type,
-                    set=set_,
-                    add=add,
-                    remove=remove,
-                    create=create,
-                    level=level,
-                )
-            )
-        return value
-
-    @override
-    def model(
-        self,
-        parent: ToMappedProtocol,
-        model_cls: type[ModelT],
-        params: dict[str, Any],
-        override: dict[str, Any],
-        level: int,
-    ) -> Any:
-        if level == 1 and self.input_data.pydantic_model is not None:
-            try:
-                model = self.input_data.pydantic_model.model_validate(params).to_mapped(override=override)
-            except ValidationError as error:
-                raise InputValidationError(error) from error
-        else:
-            model = model_cls(**params)
-        for relation in self.current_relations:
-            assert relation.field.related_model
-            relation_input = _RelationInput.from_unbound(relation, model)
-            self.input_data.relations.append(relation_input)
-        self.current_relations.clear()
-        # Return dict because .model_validate will be called at root level
-        if level != 1 and self.input_data.pydantic_model is not None:
-            return params
-        return model
-
-
-@dataclass
-class _FilteredRelationInput(Generic[ModelT, ModelFieldT]):
-    relation: _RelationInput[ModelT, ModelFieldT]
-    instance: ModelT
-
-
-@dataclass
-class LevelInput(Generic[ModelT, ModelFieldT]):
-    inputs: list[_FilteredRelationInput[ModelT, ModelFieldT]] = field(default_factory=list)
-
-
-class Input(Generic[ModelT, ModelFieldT, InputModel]):
-    def __init__(
-        self,
-        dtos: MappedDTO[InputModel] | Sequence[MappedDTO[InputModel]],
-        validation: type[MappedPydanticDTO[InputModel]] | None = None,
-        **override: Any,
-    ) -> None:
-        self.max_level = 0
-        self.relations: list[_RelationInput[ModelT, ModelFieldT]] = []
-        self.instances: list[InputModel] = []
-        self.pydantic_model = validation
-
-        dtos = dtos if isinstance(dtos, Sequence) else [dtos]
-        for index, dto in enumerate(dtos):
-            mapped = dto.to_mapped(visitor=_InputVisitor(self), override=override)
-            self.instances.append(mapped)
-            for relation in self.relations:
-                self.max_level = max(self.max_level, relation.level)
-                if relation.input_index == -1:
-                    relation.input_index = index
-
-    def filter_by_level(
-        self, relation_type: RelationType, input_types: Iterable[RelationInputType]
-    ) -> list[LevelInput[ModelT, ModelFieldT]]:
-        levels: list[LevelInput[ModelT, ModelFieldT]] = []
-        level_range = (
-            range(1, self.max_level + 1) if relation_type is RelationType.TO_MANY else range(self.max_level, 0, -1)
-        )
-        for level in level_range:
-            level_input = LevelInput()
-            for relation in self.relations:
-                input_data: list[_FilteredRelationInput[ModelT, ModelFieldT]] = []
-                for input_type in input_types:
-                    relation_input = getattr(relation, input_type)
-                    if not relation_input or relation.level != level:
-                        continue
-                    input_data.extend(
-                        _FilteredRelationInput(relation, mapped)
-                        for mapped in relation_input
-                        if relation.relation_type is relation_type
-                    )
-                    level_input.inputs.extend(input_data)
-            if level_input.inputs:
-                levels.append(level_input)
-
-        return levels

--- a/src/strawchemy/input.py
+++ b/src/strawchemy/input.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Generic, Literal, Self, TypeAlias, TypeVar, cast, override
+
+from pydantic import ValidationError
+
+from sqlalchemy import event, inspect
+from sqlalchemy.orm import NO_VALUE, MapperProperty, RelationshipDirection, object_mapper
+from strawchemy.dto.base import DTOFieldDefinition, MappedDTO, ToMappedProtocol, VisitorProtocol
+from strawchemy.graphql.mutation import (
+    RelationType,
+    RequiredToManyUpdateInputMixin,
+    RequiredToOneInputMixin,
+    ToManyCreateInputMixin,
+    ToManyUpdateInputMixin,
+    ToOneInputMixin,
+)
+
+from .exceptions import InputValidationError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from sqlalchemy.orm import DeclarativeBase, QueryableAttribute
+    from strawchemy.dto.backend.pydantic import MappedPydanticDTO
+
+
+__all__ = (
+    "Input",
+    "LevelInput",
+    "RelationType",
+    "RequiredToManyUpdateInputMixin",
+    "RequiredToOneInputMixin",
+    "ToManyCreateInputMixin",
+    "ToManyUpdateInputMixin",
+    "ToOneInputMixin",
+)
+
+T = TypeVar("T", bound=MappedDTO[Any])
+DeclarativeBaseT = TypeVar("DeclarativeBaseT", bound="DeclarativeBase")
+InputModel = TypeVar("InputModel", bound="DeclarativeBase")
+RelationInputT = TypeVar("RelationInputT", bound=MappedDTO[Any])
+RelationInputType: TypeAlias = Literal["set", "create", "add", "remove"]
+
+
+def _has_record(model: DeclarativeBase) -> bool:
+    state = inspect(model)
+    return state.persistent or state.detached
+
+
+@dataclass
+class _UnboundRelationInput:
+    attribute: MapperProperty[Any]
+    related: type[DeclarativeBase]
+    relation_type: RelationType
+    set: list[DeclarativeBase] | None = dataclasses.field(default_factory=list)
+    add: list[DeclarativeBase] = dataclasses.field(default_factory=list)
+    remove: list[DeclarativeBase] = dataclasses.field(default_factory=list)
+    create: list[DeclarativeBase] = dataclasses.field(default_factory=list)
+    input_index: int = -1
+    level: int = 0
+
+    def add_instance(self, model: DeclarativeBase) -> None:
+        if not _has_record(model):
+            self.create.append(model)
+        elif self.relation_type is RelationType.TO_ONE:
+            if self.set:
+                self.set.append(model)
+            else:
+                self.set = [model]
+        else:
+            self.add.append(model)
+
+    def __bool__(self) -> bool:
+        return bool(self.set or self.add or self.remove or self.create) or self.set is None
+
+
+@dataclass(kw_only=True)
+class RelationInput(_UnboundRelationInput):
+    parent: DeclarativeBase
+
+    def __post_init__(self) -> None:
+        if self.relation_type is RelationType.TO_ONE:
+            event.listens_for(self.attribute, "set")(self._set_event)
+        else:
+            event.listens_for(self.attribute, "append")(self._append_event)
+            event.listens_for(self.attribute, "remove")(self._remove_event)
+
+    @classmethod
+    def from_unbound(cls, unbound: _UnboundRelationInput, model: DeclarativeBase) -> Self:
+        return cls(
+            attribute=unbound.attribute,
+            related=unbound.related,
+            parent=model,
+            set=unbound.set,
+            add=unbound.add,
+            remove=unbound.remove,
+            relation_type=unbound.relation_type,
+            create=unbound.create,
+            input_index=unbound.input_index,
+            level=unbound.level,
+        )
+
+    def _set_event(self, target: DeclarativeBase, value: DeclarativeBase | None, *_: Any, **__: Any) -> None:
+        if value is None:
+            return
+        if _has_record(value):
+            self.set = [value]
+        else:
+            self.create = [value]
+
+    def _append_event(self, target: DeclarativeBase, value: DeclarativeBase, *_: Any, **__: Any) -> None:
+        if _has_record(value):
+            self.add.append(value)
+        else:
+            self.create.append(value)
+
+    def _remove_event(self, target: DeclarativeBase, value: DeclarativeBase, *_: Any, **__: Any) -> None:
+        if _has_record(value):
+            self.add = [model for model in self.add if model is not value]
+        else:
+            self.create = [model for model in self.create if model is not value]
+
+
+@dataclass
+class _InputVisitor(VisitorProtocol, Generic[InputModel]):
+    input_data: Input[InputModel]
+
+    current_relations: list[_UnboundRelationInput] = dataclasses.field(default_factory=list)
+
+    @override
+    def field_value(
+        self,
+        parent: ToMappedProtocol,
+        field: DTOFieldDefinition[DeclarativeBase, QueryableAttribute[Any]],
+        value: Any,
+        level: int,
+    ) -> Any:
+        field_value = getattr(parent, field.model_field_name)
+        add, remove, create = [], [], []
+        set_: list[Any] | None = []
+        relation_type = RelationType.TO_MANY
+        if isinstance(field_value, ToOneInputMixin):
+            relation_type = RelationType.TO_ONE
+            if field_value.set is None:
+                set_ = None
+            elif field_value.set:
+                set_ = [field_value.set.to_mapped()]
+        elif isinstance(field_value, ToManyUpdateInputMixin | ToManyCreateInputMixin):
+            if field_value.set:
+                set_ = [dto.to_mapped() for dto in field_value.set]
+            if field_value.add:
+                add = [dto.to_mapped() for dto in field_value.add]
+        if isinstance(field_value, ToManyUpdateInputMixin) and field_value.remove:
+            remove = [dto.to_mapped() for dto in field_value.remove]
+        if (
+            isinstance(field_value, ToOneInputMixin | ToManyUpdateInputMixin | ToManyCreateInputMixin)
+            and field_value.create
+        ):
+            create = value if isinstance(value, list) else [value]
+        if set_ is None or set_ or add or remove or create:
+            assert field.related_model
+            self.current_relations.append(
+                _UnboundRelationInput(
+                    attribute=field.model_field.property,
+                    related=field.related_model,
+                    relation_type=relation_type,
+                    set=set_,
+                    add=add,
+                    remove=remove,
+                    create=create,
+                    level=level,
+                )
+            )
+        return value
+
+    @override
+    def model(
+        self,
+        parent: ToMappedProtocol,
+        model_cls: type[DeclarativeBase],
+        params: dict[str, Any],
+        override: dict[str, Any],
+        level: int,
+    ) -> Any:
+        if level == 1 and self.input_data.pydantic_model is not None:
+            try:
+                model = self.input_data.pydantic_model.model_validate(params).to_mapped(override=override)
+            except ValidationError as error:
+                raise InputValidationError(error) from error
+        else:
+            model = model_cls(**params)
+        for relation in self.current_relations:
+            self.input_data.add_relation(RelationInput.from_unbound(relation, model))
+        self.current_relations.clear()
+        # Return dict because .model_validate will be called at root level
+        if level != 1 and self.input_data.pydantic_model is not None:
+            return params
+        return model
+
+
+@dataclass
+class _FilteredRelationInput:
+    relation: RelationInput
+    instance: DeclarativeBase
+
+
+@dataclass
+class LevelInput:
+    inputs: list[_FilteredRelationInput] = field(default_factory=list)
+
+
+class Input(Generic[InputModel]):
+    def __init__(
+        self,
+        dtos: MappedDTO[InputModel] | Sequence[MappedDTO[InputModel]],
+        validation: type[MappedPydanticDTO[InputModel]] | None = None,
+        **override: Any,
+    ) -> None:
+        self.max_level = 0
+        self.relations: list[RelationInput] = []
+        self.instances: list[InputModel] = []
+        self.dtos: list[MappedDTO[InputModel]] = []
+        self.pydantic_model = validation
+
+        dtos = dtos if isinstance(dtos, Sequence) else [dtos]
+        for index, dto in enumerate(dtos):
+            mapped = dto.to_mapped(visitor=_InputVisitor(self), override=override)
+            self.instances.append(mapped)
+            self.dtos.append(dto)
+            for relation in self.relations:
+                if relation.input_index == -1:
+                    relation.input_index = index
+
+    def _add_non_input_relations(
+        self, model: DeclarativeBase, input_index: int, _level: int = 0, _seen: set[DeclarativeBase] | None = None
+    ) -> None:
+        seen = _seen or set()
+        _level += 1
+        loaded_attributes = {name for name, attr in inspect(model).attrs.items() if attr.loaded_value is not NO_VALUE}
+        level_relations = {relation.attribute.key for relation in self.relations if relation.level == _level}
+        mapper = object_mapper(model)
+        seen.add(model)
+        for relationship in mapper.relationships:
+            if relationship.key not in loaded_attributes or relationship.key in level_relations:
+                continue
+            relationship_value = getattr(model, relationship.key)
+            # We do not merge this check with the one above to avoid MissingGreenlet error
+            # If the attribute is not loaded when using asyncio, it won't appears in loaded_attributes
+            if relationship_value is None:
+                continue
+            relation_type = (
+                RelationType.TO_MANY
+                if relationship.direction in {RelationshipDirection.MANYTOMANY, RelationshipDirection.ONETOMANY}
+                else RelationType.TO_ONE
+            )
+            relation = RelationInput(
+                attribute=relationship,
+                parent=model,
+                level=_level,
+                input_index=input_index,
+                relation_type=relation_type,
+                related=relationship.entity.mapper.class_,
+            )
+            if isinstance(relationship_value, tuple | list):
+                model_list = cast("list[DeclarativeBase]", relationship_value)
+                for value in model_list:
+                    if value in seen:
+                        continue
+                    self._add_non_input_relations(value, input_index, _level, seen)
+                    relation.add_instance(value)
+            elif relationship_value not in seen:
+                self._add_non_input_relations(relationship_value, input_index, _level, seen)
+                relation.add_instance(relationship_value)
+            self.add_relation(relation)
+
+    def add_relation(self, relation: RelationInput) -> None:
+        if relation:
+            self.relations.append(relation)
+            self.max_level = max(self.max_level, relation.level)
+
+    def filter_by_level(
+        self, relation_type: RelationType, input_types: Iterable[RelationInputType]
+    ) -> list[LevelInput]:
+        levels: list[LevelInput] = []
+        level_range = (
+            range(1, self.max_level + 1) if relation_type is RelationType.TO_MANY else range(self.max_level, 0, -1)
+        )
+        for level in level_range:
+            level_input = LevelInput()
+            for relation in self.relations:
+                input_data: list[_FilteredRelationInput] = []
+                for input_type in input_types:
+                    relation_input = getattr(relation, input_type)
+                    if not relation_input or relation.level != level:
+                        continue
+                    input_data.extend(
+                        _FilteredRelationInput(relation, mapped)
+                        for mapped in relation_input
+                        if relation.relation_type is relation_type
+                    )
+                    level_input.inputs.extend(input_data)
+            if level_input.inputs:
+                levels.append(level_input)
+
+        return levels
+
+    def add_non_input_relations(self) -> None:
+        for i, instance in enumerate(self.instances):
+            self._add_non_input_relations(instance, i)

--- a/src/strawchemy/sqlalchemy/repository/typing.py
+++ b/src/strawchemy/sqlalchemy/repository/typing.py
@@ -1,9 +1,0 @@
-from __future__ import annotations
-
-from typing import TYPE_CHECKING, Any, TypeAlias
-
-if TYPE_CHECKING:
-    from sqlalchemy.orm import DeclarativeBase, QueryableAttribute
-    from strawchemy.graphql.mutation import Input
-
-SQLAlchemyInput: TypeAlias = "Input[DeclarativeBase, QueryableAttribute[Any], Any]"

--- a/src/strawchemy/strawberry/inspector.py
+++ b/src/strawchemy/strawberry/inspector.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from strawchemy.dto.base import Relation
     from strawchemy.graph import Node
 
-    from .factory import StrawberryRegistry
+    from ._registry import StrawberryRegistry
 
 __all__ = ("_StrawberryModelInspector",)
 

--- a/src/strawchemy/strawberry/repository/_async.py
+++ b/src/strawchemy/strawberry/repository/_async.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from sqlalchemy import Select
     from strawberry import Info
     from strawchemy.graphql.dto import BooleanFilterDTO, EnumDTO, OrderByDTO
-    from strawchemy.sqlalchemy.repository.typing import SQLAlchemyInput
+    from strawchemy.input import Input
     from strawchemy.sqlalchemy.typing import AnyAsyncSession
     from strawchemy.strawberry.typing import AsyncSessionGetter, StrawchemyTypeFromPydantic
 
@@ -121,24 +121,24 @@ class StrawchemyAsyncRepository(StrawchemyRepository[T]):
             return self._tree.aggregation_query_result_to_strawberry_type(query_results)
         return self._tree.query_result_to_strawberry_type(query_results)
 
-    async def create_many(self, data: SQLAlchemyInput) -> Sequence[T]:
+    async def create_many(self, data: Input[Any]) -> Sequence[T]:
         query_results = await self.graphql_repository().create(data, self._tree)
         return self._tree.query_result_to_strawberry_type(query_results)
 
-    async def create(self, data: SQLAlchemyInput) -> T:
+    async def create(self, data: Input[Any]) -> T:
         query_results = await self.graphql_repository().create(data, self._tree)
         return self._tree.node_result_to_strawberry_type(query_results.one())
 
-    async def update_many_by_id(self, data: SQLAlchemyInput) -> Sequence[T]:
+    async def update_many_by_id(self, data: Input[Any]) -> Sequence[T]:
         query_results = await self.graphql_repository().update_by_ids(data, self._tree)
         return self._tree.query_result_to_strawberry_type(query_results)
 
-    async def update_by_id(self, data: SQLAlchemyInput) -> T:
+    async def update_by_id(self, data: Input[Any]) -> T:
         query_results = await self.graphql_repository().update_by_ids(data, self._tree)
         return self._tree.node_result_to_strawberry_type(query_results.one())
 
     async def update_by_filter(
-        self, data: SQLAlchemyInput, filter_input: StrawchemyTypeFromPydantic[BooleanFilterDTO[Any, Any]]
+        self, data: Input[Any], filter_input: StrawchemyTypeFromPydantic[BooleanFilterDTO[Any, Any]]
     ) -> Sequence[T]:
         query_results = await self.graphql_repository().update_by_filter(data, filter_input.to_pydantic(), self._tree)
         return self._tree.query_result_to_strawberry_type(query_results)

--- a/src/strawchemy/strawberry/repository/_sync.py
+++ b/src/strawchemy/strawberry/repository/_sync.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from sqlalchemy import Select
     from strawberry import Info
     from strawchemy.graphql.dto import BooleanFilterDTO, EnumDTO, OrderByDTO
-    from strawchemy.sqlalchemy.repository.typing import SQLAlchemyInput
+    from strawchemy.input import Input
     from strawchemy.sqlalchemy.typing import AnySyncSession
     from strawchemy.strawberry.typing import StrawchemyTypeFromPydantic, SyncSessionGetter
 
@@ -123,24 +123,24 @@ class StrawchemySyncRepository(StrawchemyRepository[T]):
             return self._tree.aggregation_query_result_to_strawberry_type(query_results)
         return self._tree.query_result_to_strawberry_type(query_results)
 
-    def create_many(self, data: SQLAlchemyInput) -> Sequence[T]:
+    def create_many(self, data: Input[Any]) -> Sequence[T]:
         query_results = self.graphql_repository().create(data, self._tree)
         return self._tree.query_result_to_strawberry_type(query_results)
 
-    def create(self, data: SQLAlchemyInput) -> T:
+    def create(self, data: Input[Any]) -> T:
         query_results = self.graphql_repository().create(data, self._tree)
         return self._tree.node_result_to_strawberry_type(query_results.one())
 
-    def update_many_by_id(self, data: SQLAlchemyInput) -> Sequence[T]:
+    def update_many_by_id(self, data: Input[Any]) -> Sequence[T]:
         query_results = self.graphql_repository().update_by_ids(data, self._tree)
         return self._tree.query_result_to_strawberry_type(query_results)
 
-    def update_by_id(self, data: SQLAlchemyInput) -> T:
+    def update_by_id(self, data: Input[Any]) -> T:
         query_results = self.graphql_repository().update_by_ids(data, self._tree)
         return self._tree.node_result_to_strawberry_type(query_results.one())
 
     def update_by_filter(
-        self, data: SQLAlchemyInput, filter_input: StrawchemyTypeFromPydantic[BooleanFilterDTO[Any, Any]]
+        self, data: Input[Any], filter_input: StrawchemyTypeFromPydantic[BooleanFilterDTO[Any, Any]]
     ) -> Sequence[T]:
         query_results = self.graphql_repository().update_by_filter(data, filter_input.to_pydantic(), self._tree)
         return self._tree.query_result_to_strawberry_type(query_results)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import pytest
 from strawchemy.mapper import Strawchemy
 
 import strawberry
-from sqlalchemy.orm import DeclarativeBase, QueryableAttribute
 from syrupy.assertion import SnapshotAssertion
 from syrupy.extensions.amber import AmberSnapshotExtension
 from tests.utils import sqlalchemy_dataclass_factory, sqlalchemy_pydantic_factory
@@ -31,7 +30,7 @@ def sql_snapshot(snapshot: SnapshotAssertion) -> SnapshotAssertion:
 
 
 @pytest.fixture
-def strawchemy() -> Strawchemy[DeclarativeBase, QueryableAttribute[Any]]:
+def strawchemy() -> Strawchemy:
     return Strawchemy()
 
 

--- a/tests/integration/__snapshots__/test_mutations.ambr
+++ b/tests/integration/__snapshots__/test_mutations.ambr
@@ -1,4 +1,46 @@
 # serializer version: 1
+# name: test_column_override[session-tracked-async-asyncpg_engine]
+  '''
+  INSERT INTO color (name, id, created_at, updated_at)
+  VALUES ($1::VARCHAR, $2::UUID, $3::TIMESTAMP WITH TIME ZONE, $4::TIMESTAMP WITH TIME ZONE)
+  '''
+# ---
+# name: test_column_override[session-tracked-async-asyncpg_engine].1
+  '''
+  SELECT color.name,
+         color.id
+    FROM color AS color
+   WHERE color.id IN (__[POSTCOMPILE_id_1])
+  '''
+# ---
+# name: test_column_override[session-tracked-async-psycopg_async_engine]
+  '''
+  INSERT INTO color (name, id, created_at, updated_at)
+  VALUES (%(name)s::VARCHAR, %(id)s::UUID, %(created_at)s::TIMESTAMP WITH TIME ZONE, %(updated_at)s::TIMESTAMP WITH TIME ZONE)
+  '''
+# ---
+# name: test_column_override[session-tracked-async-psycopg_async_engine].1
+  '''
+  SELECT color.name,
+         color.id
+    FROM color AS color
+   WHERE color.id IN (__[POSTCOMPILE_id_1])
+  '''
+# ---
+# name: test_column_override[session-tracked-sync-psycopg_engine]
+  '''
+  INSERT INTO color (name, id, created_at, updated_at)
+  VALUES (%(name)s::VARCHAR, %(id)s::UUID, %(created_at)s::TIMESTAMP WITH TIME ZONE, %(updated_at)s::TIMESTAMP WITH TIME ZONE)
+  '''
+# ---
+# name: test_column_override[session-tracked-sync-psycopg_engine].1
+  '''
+  SELECT color.name,
+         color.id
+    FROM color AS color
+   WHERE color.id IN (__[POSTCOMPILE_id_1])
+  '''
+# ---
 # name: test_create[session-tracked-createColor-async-asyncpg_engine]
   '''
   INSERT INTO color (name, id, created_at, updated_at)
@@ -174,48 +216,6 @@
   '''
 # ---
 # name: test_create[session-tracked-createValidatedColorAllFragments-manual-async-psycopg_async_engine].1
-  '''
-  SELECT color.name,
-         color.id
-    FROM color AS color
-   WHERE color.id IN (__[POSTCOMPILE_id_1])
-  '''
-# ---
-# name: test_create[session-tracked-createValidatedColorAllFragments-manual-override-async-asyncpg_engine]
-  '''
-  INSERT INTO color (name, id, created_at, updated_at)
-  VALUES ($1::VARCHAR, $2::UUID, $3::TIMESTAMP WITH TIME ZONE, $4::TIMESTAMP WITH TIME ZONE)
-  '''
-# ---
-# name: test_create[session-tracked-createValidatedColorAllFragments-manual-override-async-asyncpg_engine].1
-  '''
-  SELECT color.name,
-         color.id
-    FROM color AS color
-   WHERE color.id IN (__[POSTCOMPILE_id_1])
-  '''
-# ---
-# name: test_create[session-tracked-createValidatedColorAllFragments-manual-override-async-psycopg_async_engine]
-  '''
-  INSERT INTO color (name, id, created_at, updated_at)
-  VALUES (%(name)s::VARCHAR, %(id)s::UUID, %(created_at)s::TIMESTAMP WITH TIME ZONE, %(updated_at)s::TIMESTAMP WITH TIME ZONE)
-  '''
-# ---
-# name: test_create[session-tracked-createValidatedColorAllFragments-manual-override-async-psycopg_async_engine].1
-  '''
-  SELECT color.name,
-         color.id
-    FROM color AS color
-   WHERE color.id IN (__[POSTCOMPILE_id_1])
-  '''
-# ---
-# name: test_create[session-tracked-createValidatedColorAllFragments-manual-override-sync-psycopg_engine]
-  '''
-  INSERT INTO color (name, id, created_at, updated_at)
-  VALUES (%(name)s::VARCHAR, %(id)s::UUID, %(created_at)s::TIMESTAMP WITH TIME ZONE, %(updated_at)s::TIMESTAMP WITH TIME ZONE)
-  '''
-# ---
-# name: test_create[session-tracked-createValidatedColorAllFragments-manual-override-sync-psycopg_engine].1
   '''
   SELECT color.name,
          color.id
@@ -1035,48 +1035,6 @@
   '''
   INSERT INTO fruit (name, color_id, adjectives, derived_product_id, id, created_at, updated_at)
   VALUES (%(name)s::VARCHAR, %(color_id)s::UUID, %(adjectives)s::TEXT[], %(derived_product_id)s::UUID, %(id)s::UUID, %(created_at)s::TIMESTAMP WITH TIME ZONE, %(updated_at)s::TIMESTAMP WITH TIME ZONE)
-  '''
-# ---
-# name: test_custom_mutation_with_arg_override[session-tracked-async-asyncpg_engine]
-  '''
-  INSERT INTO color (name, id, created_at, updated_at)
-  VALUES ($1::VARCHAR, $2::UUID, $3::TIMESTAMP WITH TIME ZONE, $4::TIMESTAMP WITH TIME ZONE)
-  '''
-# ---
-# name: test_custom_mutation_with_arg_override[session-tracked-async-asyncpg_engine].1
-  '''
-  SELECT color.name,
-         color.id
-    FROM color AS color
-   WHERE color.id IN (__[POSTCOMPILE_id_1])
-  '''
-# ---
-# name: test_custom_mutation_with_arg_override[session-tracked-async-psycopg_async_engine]
-  '''
-  INSERT INTO color (name, id, created_at, updated_at)
-  VALUES (%(name)s::VARCHAR, %(id)s::UUID, %(created_at)s::TIMESTAMP WITH TIME ZONE, %(updated_at)s::TIMESTAMP WITH TIME ZONE)
-  '''
-# ---
-# name: test_custom_mutation_with_arg_override[session-tracked-async-psycopg_async_engine].1
-  '''
-  SELECT color.name,
-         color.id
-    FROM color AS color
-   WHERE color.id IN (__[POSTCOMPILE_id_1])
-  '''
-# ---
-# name: test_custom_mutation_with_arg_override[session-tracked-sync-psycopg_engine]
-  '''
-  INSERT INTO color (name, id, created_at, updated_at)
-  VALUES (%(name)s::VARCHAR, %(id)s::UUID, %(created_at)s::TIMESTAMP WITH TIME ZONE, %(updated_at)s::TIMESTAMP WITH TIME ZONE)
-  '''
-# ---
-# name: test_custom_mutation_with_arg_override[session-tracked-sync-psycopg_engine].1
-  '''
-  SELECT color.name,
-         color.id
-    FROM color AS color
-   WHERE color.id IN (__[POSTCOMPILE_id_1])
   '''
 # ---
 # name: test_delete_all[session-tracked-async-asyncpg_engine]

--- a/tests/unit/mapping/test_model_config.py
+++ b/tests/unit/mapping/test_model_config.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import pytest
 
-from sqlalchemy.orm import DeclarativeBase, QueryableAttribute
 from strawberry.types import get_object_definition
 from tests.unit.models import User
 
@@ -15,9 +14,7 @@ TYPE_DECORATOR_NAMES: list[str] = ["type", "aggregate", "filter", "aggregate_fil
 
 
 @pytest.mark.parametrize("decorator", TYPE_DECORATOR_NAMES)
-def test_type_no_purpose_excluded(
-    decorator: str, strawchemy: Strawchemy[DeclarativeBase, QueryableAttribute[Any]]
-) -> None:
+def test_type_no_purpose_excluded(decorator: str, strawchemy: Strawchemy) -> None:
     @getattr(strawchemy, decorator)(User, include="all", override=True)
     class UserType: ...
 
@@ -26,9 +23,7 @@ def test_type_no_purpose_excluded(
 
 
 @pytest.mark.parametrize("decorator", ["create_input", "pk_update_input", "filter_update_input"])
-def test_type_no_purpose_excluded_input(
-    decorator: str, strawchemy: Strawchemy[DeclarativeBase, QueryableAttribute[Any]]
-) -> None:
+def test_type_no_purpose_excluded_input(decorator: str, strawchemy: Strawchemy) -> None:
     @getattr(strawchemy, decorator)(User, include="all")
     class UserType: ...
 

--- a/tests/unit/mapping/test_types.py
+++ b/tests/unit/mapping/test_types.py
@@ -16,7 +16,6 @@ from strawchemy.strawberry.scalars import Interval
 from strawchemy.testing.pytest_plugin import MockContext
 
 import strawberry
-from sqlalchemy.orm import DeclarativeBase, QueryableAttribute
 from strawberry import auto
 from strawberry.scalars import JSON
 from strawberry.types import get_object_definition
@@ -35,7 +34,7 @@ if TYPE_CHECKING:
 SCALAR_OVERRIDES: dict[object, Any] = {dict[str, Any]: JSON, timedelta: Interval}
 
 
-def test_type_instance(strawchemy: Strawchemy[DeclarativeBase, QueryableAttribute[Any]]) -> None:
+def test_type_instance(strawchemy: Strawchemy) -> None:
     @strawchemy.type(User)
     class UserType:
         id: auto
@@ -46,7 +45,7 @@ def test_type_instance(strawchemy: Strawchemy[DeclarativeBase, QueryableAttribut
     assert user.name == "user"
 
 
-def test_type_instance_auto_as_str(strawchemy: Strawchemy[DeclarativeBase, QueryableAttribute[Any]]) -> None:
+def test_type_instance_auto_as_str(strawchemy: Strawchemy) -> None:
     @strawchemy.type(User)
     class UserType:
         id: "auto"
@@ -57,7 +56,7 @@ def test_type_instance_auto_as_str(strawchemy: Strawchemy[DeclarativeBase, Query
     assert user.name == "user"
 
 
-def test_input_instance(strawchemy: Strawchemy[DeclarativeBase, QueryableAttribute[Any]]) -> None:
+def test_input_instance(strawchemy: Strawchemy) -> None:
     @strawchemy.create_input(User)
     class InputType:
         id: auto
@@ -68,7 +67,7 @@ def test_input_instance(strawchemy: Strawchemy[DeclarativeBase, QueryableAttribu
     assert user.name == "user"  # pyright: ignore[reportAttributeAccessIssue]
 
 
-def test_field_metadata_default(strawchemy: Strawchemy[DeclarativeBase, QueryableAttribute[Any]]) -> None:
+def test_field_metadata_default(strawchemy: Strawchemy) -> None:
     """Test metadata default.
 
     Test that textual metadata from the SQLAlchemy model isn't reflected in the Strawberry


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

-

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Refactor mutation input handling to automatically track SQLAlchemy relationship changes set directly on model instances.

New Features:
- Allow mutations to automatically detect and handle relationship changes made directly on SQLAlchemy model instances within the `Input` object.
- Enable setting relationships on model instances before passing them to the repository, simplifying mutation logic by automatically tracking these changes.
- Introduce `Input.add_non_input_relations` to discover and manage relationships not explicitly defined in the DTO.
- Utilize SQLAlchemy events to track relationship modifications (`set`, `append`, `remove`) within the `Input` object.
- Centralize input processing logic, including relationship tracking, into a new `strawchemy.input` module.
- Adapt repository methods (`create`, `update_by_ids`, `update_by_filter`) to utilize the new `Input` object and its relationship tracking capabilities.
- Refine type hinting across factories and repositories, replacing generic types with specific SQLAlchemy types like `DeclarativeBase` and `QueryableAttribute`.
- Rename various internal `Strawberry*` classes and modules to `Strawchemy*` for better consistency.
- Relocate `InputValidationError` to the main `exceptions.py` module.
- Add integration tests verifying the automatic handling of both to-one and to-many relationships assigned directly to model instances during creation mutations.