### PR TITLE
fix(input): dataclass models tracking not working

### DIFF
--- a/tests/unit/test_mutation_input.py
+++ b/tests/unit/test_mutation_input.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from strawchemy import Strawchemy
+from strawchemy.input import Input
+
+from .dc_models import ColorDataclass, FruitDataclass
+from .models import Color, Fruit
+
+
+@pytest.mark.parametrize(("color_model", "fruit_model"), [(Color, Fruit), (ColorDataclass, FruitDataclass)])
+def test_add_non_input_relationships(
+    color_model: type[Color | ColorDataclass], fruit_model: type[Fruit | FruitDataclass]
+) -> None:
+    strawchemy = Strawchemy()
+
+    @strawchemy.create_input(color_model, include="all")
+    class ColorInput: ...
+
+    color = ColorInput(name="Blue")  # pyright: ignore[reportCallIssue]
+    color_input = Input(color)
+    assert len(color_input.relations) == 0
+    color_input.instances[0].fruits.append(fruit_model(name="Apple", color_id=uuid4(), sweetness=1, color=None))  # pyright: ignore[reportArgumentType]
+    color_input.add_non_input_relations()
+    assert len(color_input.relations) == 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

-

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Fix tracking of dataclass models in input relations by using a more robust model identity method

Bug Fixes:
- Resolved issue with tracking relationships for dataclass models in input relations

Enhancements:
- Introduced a new _model_identity method to handle model tracking more reliably

Tests:
- Added a parametrized test to verify relationship tracking for both SQLAlchemy and dataclass models