### PR TITLE
feat(mutation): initial upsert support

### DIFF
--- a/examples/testapp/pyproject.toml
+++ b/examples/testapp/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.9"
 dependencies = [
   "aiosqlite",
   "litestar[sqlalchemy,standard]",
+  "pydantic",
   "sqlalchemy",
   "strawberry-graphql",
 ]

--- a/examples/testapp/testapp/app.py
+++ b/examples/testapp/testapp/app.py
@@ -18,6 +18,7 @@ config = SQLAlchemyAsyncConfig(
     connection_string="sqlite+aiosqlite:///basic_async.sqlite",
     create_all=True,
     metadata=Base.metadata,
+    enable_touch_updated_timestamp_listener=False,  # Disturb strawchemy integration tests
     engine_config=EngineConfig(echo=True),
 )
 

--- a/examples/testapp/testapp/schema.py
+++ b/examples/testapp/testapp/schema.py
@@ -16,6 +16,7 @@ from .types import (
     TicketPartial,
     TicketType,
     TicketUpdate,
+    TicketUpsertFields,
     strawchemy,
 )
 
@@ -37,6 +38,9 @@ class Mutation:
         TicketCreate, validation=PydanticValidation(TicketCreateValidation)
     )
     create_tickets: list[TicketType] = strawchemy.create(TicketCreate)
+    upsert_ticket: TicketType = strawchemy.upsert(
+        TicketCreate, upsert_fields=TicketUpsertFields, filter_input=TicketFilter
+    )
 
     create_project: ProjectType = strawchemy.create(ProjectCreate)
     create_projects: list[ProjectType] = strawchemy.create(ProjectCreate)

--- a/examples/testapp/testapp/schema.py
+++ b/examples/testapp/testapp/schema.py
@@ -16,6 +16,7 @@ from .types import (
     TicketPartial,
     TicketType,
     TicketUpdate,
+    TicketUpsertConflictFields,
     TicketUpsertFields,
     strawchemy,
 )
@@ -39,7 +40,7 @@ class Mutation:
     )
     create_tickets: list[TicketType] = strawchemy.create(TicketCreate)
     upsert_ticket: TicketType = strawchemy.upsert(
-        TicketCreate, upsert_fields=TicketUpsertFields, filter_input=TicketFilter
+        TicketCreate, update_fields=TicketUpsertFields, conflict_fields=TicketUpsertConflictFields
     )
 
     create_project: ProjectType = strawchemy.create(ProjectCreate)

--- a/examples/testapp/testapp/types.py
+++ b/examples/testapp/testapp/types.py
@@ -24,8 +24,12 @@ class TicketFilter: ...
 class TicketType: ...
 
 
-@strawchemy.upsert_fields(Ticket, include="all")
+@strawchemy.upsert_update_fields(Ticket, include="all")
 class TicketUpsertFields: ...
+
+
+@strawchemy.upsert_conflict_fields(Ticket, include="all")
+class TicketUpsertConflictFields: ...
 
 
 @strawchemy.create_input(Ticket, include="all")

--- a/examples/testapp/testapp/types.py
+++ b/examples/testapp/testapp/types.py
@@ -9,44 +9,23 @@ from .models import Milestone, Project, Ticket
 
 strawchemy = Strawchemy(StrawchemyConfig("sqlite", repository_type=StrawchemyAsyncRepository))
 
-# Filter
-
-
-@strawchemy.filter(Ticket, include="all")
-class TicketFilter: ...
-
-
-@strawchemy.filter(Project, include="all")
-class ProjectFilter: ...
-
-
-# Order
+# Ticket
 
 
 @strawchemy.order(Ticket, include="all")
 class TicketOrder: ...
 
 
-@strawchemy.order(Project, include="all")
-class ProjectOrder: ...
-
-
-# types
+@strawchemy.filter(Ticket, include="all")
+class TicketFilter: ...
 
 
 @strawchemy.type(Ticket, include="all", filter_input=TicketFilter, order_by=TicketOrder, override=True)
 class TicketType: ...
 
 
-@strawchemy.type(Project, include="all", filter_input=ProjectFilter, order_by=ProjectOrder, override=True)
-class ProjectType: ...
-
-
-@strawchemy.type(Milestone, include="all", override=True)
-class MilestoneType: ...
-
-
-# Input types
+@strawchemy.upsert_fields(Ticket, include="all")
+class TicketUpsertFields: ...
 
 
 @strawchemy.create_input(Ticket, include="all")
@@ -61,8 +40,30 @@ class TicketUpdate: ...
 class TicketPartial: ...
 
 
+# Project
+
+
+@strawchemy.order(Project, include="all")
+class ProjectOrder: ...
+
+
+@strawchemy.filter(Project, include="all")
+class ProjectFilter: ...
+
+
+@strawchemy.type(Project, include="all", filter_input=ProjectFilter, order_by=ProjectOrder, override=True)
+class ProjectType: ...
+
+
 @strawchemy.create_input(Project, include="all", override=True)
 class ProjectCreate: ...
+
+
+# Milestone
+
+
+@strawchemy.type(Milestone, include="all", override=True)
+class MilestoneType: ...
 
 
 @strawchemy.create_input(Milestone, include="all", override=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ test = [
   { include-group = "postgres" },
   { include-group = "mysql" },
   { include-group = "aiosqlite" },
+  "testapp",
   "nox[uv]",
   "pytest",
   "pytest-cov",

--- a/src/strawchemy/constants.py
+++ b/src/strawchemy/constants.py
@@ -19,3 +19,4 @@ DATA_KEY = "data"
 JSON_PATH_KEY = "path"
 
 UPSERT_UPDATE_FIELDS = "update_fields"
+UPSERT_CONFLICT_FIELDS = "conflict_fields"

--- a/src/strawchemy/constants.py
+++ b/src/strawchemy/constants.py
@@ -17,3 +17,5 @@ NODES_KEY = "nodes"
 
 DATA_KEY = "data"
 JSON_PATH_KEY = "path"
+
+UPSERT_UPDATE_FIELDS = "update_fields"

--- a/src/strawchemy/dto/inspectors/sqlalchemy.py
+++ b/src/strawchemy/dto/inspectors/sqlalchemy.py
@@ -420,7 +420,8 @@ class SQLAlchemyInspector(ModelInspector[DeclarativeBase, QueryableAttribute[Any
             return False
         return any(self._relationship_required(relationship) for relationship in model_field.property._reverse_property)  # noqa: SLF001
 
-    def unique_constraints(self, model: type[DeclarativeBase]) -> list[ColumnCollectionConstraint | Index]:
+    @classmethod
+    def unique_constraints(cls, model: type[DeclarativeBase]) -> list[ColumnCollectionConstraint | Index]:
         if not isinstance(model.__table__, Table):
             return []
         return [

--- a/src/strawchemy/dto/inspectors/sqlalchemy.py
+++ b/src/strawchemy/dto/inspectors/sqlalchemy.py
@@ -11,7 +11,6 @@ from typing_extensions import TypeIs
 
 from sqlalchemy import (
     Column,
-    Index,
     PrimaryKeyConstraint,
     Sequence,
     SQLColumnExpression,
@@ -421,11 +420,11 @@ class SQLAlchemyInspector(ModelInspector[DeclarativeBase, QueryableAttribute[Any
         return any(self._relationship_required(relationship) for relationship in model_field.property._reverse_property)  # noqa: SLF001
 
     @classmethod
-    def unique_constraints(cls, model: type[DeclarativeBase]) -> list[ColumnCollectionConstraint | Index]:
+    def unique_constraints(cls, model: type[DeclarativeBase]) -> list[ColumnCollectionConstraint]:
         if not isinstance(model.__table__, Table):
             return []
         return [
             constraint
             for constraint in model.__table__.constraints
-            if isinstance(constraint, PrimaryKeyConstraint | UniqueConstraint | postgresql.ExcludeConstraint | Index)
+            if isinstance(constraint, PrimaryKeyConstraint | UniqueConstraint | postgresql.ExcludeConstraint)
         ]

--- a/src/strawchemy/sqlalchemy/_query.py
+++ b/src/strawchemy/sqlalchemy/_query.py
@@ -428,8 +428,8 @@ class SubqueryBuilder(Generic[DeclarativeT]):
     def _distinct_on_rank_column(self) -> str:
         return self.scope.key("distinct_on_rank")
 
-    def distinct_on_condition(self) -> ColumnElement[bool]:
-        return self.scope.literal_column(self.name, self._distinct_on_rank_column) == 1
+    def distinct_on_condition(self, aliased_subquery: AliasedClass[DeclarativeT]) -> ColumnElement[bool]:
+        return inspect(aliased_subquery).selectable.columns[self._distinct_on_rank_column] == 1
 
     @property
     def name(self) -> str:

--- a/src/strawchemy/sqlalchemy/_query.py
+++ b/src/strawchemy/sqlalchemy/_query.py
@@ -70,14 +70,14 @@ class Join:
     order_nodes: list[QueryNodeType] = dataclasses.field(default_factory=list)
 
     @property
-    def _selectable(self) -> NamedFromClause:
+    def _relationship(self) -> RelationshipProperty[Any]:
+        return cast("RelationshipProperty[Any]", self.node.value.model_field.property)
+
+    @property
+    def selectable(self) -> NamedFromClause:
         if isinstance(self.target, AliasedClass):
             return cast("NamedFromClause", inspect(self.target).selectable)
         return self.target
-
-    @property
-    def _relationship(self) -> RelationshipProperty[Any]:
-        return cast("RelationshipProperty[Any]", self.node.value.model_field.property)
 
     @property
     def order(self) -> int:
@@ -85,7 +85,7 @@ class Join:
 
     @property
     def name(self) -> str:
-        return self._selectable.name
+        return self.selectable.name
 
     @property
     def to_many(self) -> bool:
@@ -120,9 +120,9 @@ class AggregationJoin(Join):
 
     @property
     def _inner_select(self) -> Select[Any]:
-        if isinstance(self._selectable, CTE):
-            return cast("Select[Any]", self._selectable.element)
-        self_join = cast("AliasedReturnsRows", self._selectable)
+        if isinstance(self.selectable, CTE):
+            return cast("Select[Any]", self.selectable.element)
+        self_join = cast("AliasedReturnsRows", self.selectable)
         return cast("Select[Any]", cast("Subquery", self_join.element).element)
 
     def _existing_function_column(self, new_column: ColumnElement[Any]) -> ColumnElement[Any] | None:
@@ -151,7 +151,7 @@ class AggregationJoin(Join):
     def add_column_to_subquery(self, column: ColumnElement[Any]) -> None:
         new_sub_select = self._inner_select.add_columns(self._ensure_unique_name(column))
 
-        if isinstance(self._selectable, Lateral):
+        if isinstance(self.selectable, Lateral):
             new_sub_select = new_sub_select.lateral(self.name)
         else:
             new_sub_select = new_sub_select.cte(self.name)
@@ -467,7 +467,9 @@ class SubqueryBuilder(Generic[DeclarativeT]):
             )
         for function_node in self.scope.referenced_function_nodes:
             only_columns.append(self.scope.columns[function_node])
-            self.scope.columns[function_node] = self.scope.literal_column(self.name, self.scope.key(function_node))
+            self.scope.columns[function_node] = self.scope.scoped_column(
+                inspect(self.alias).selectable, self.scope.key(function_node)
+            )
 
         if query.distinct_on and not query.use_distinct_on:
             order_by_expressions = query.order_by.expressions if query.order_by else []

--- a/src/strawchemy/sqlalchemy/_scope.py
+++ b/src/strawchemy/sqlalchemy/_scope.py
@@ -24,7 +24,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, Self, TypeAlias, override
 
-from sqlalchemy import ColumnElement, Function, Label, func, inspect, literal_column
+from sqlalchemy import ColumnElement, FromClause, Function, Label, Select, func, inspect
 from sqlalchemy import cast as sqla_cast
 from sqlalchemy import distinct as sqla_distinct
 from sqlalchemy.dialects import postgresql
@@ -484,15 +484,11 @@ class QueryScope(Generic[DeclarativeT]):
 
         return columns
 
-    def literal_column(self, from_name: str, column_name: str) -> Label[Any]:
-        return literal_column(f"{(from_name)}.{column_name}").label(self._add_scope_id(column_name))
+    def scoped_column(self, clause: Select[Any] | FromClause, column_name: str) -> Label[Any]:
+        columns = clause.selected_columns if isinstance(clause, Select) else clause.columns
+        return columns[column_name].label(self._add_scope_id(column_name))
 
-    def set_relation_alias(
-        self,
-        node: QueryNodeType,
-        side: RelationshipSide,
-        alias: AliasedClass[Any],
-    ) -> None:
+    def set_relation_alias(self, node: QueryNodeType, side: RelationshipSide, alias: AliasedClass[Any]) -> None:
         self._node_alias_map[(node, side)] = alias
 
     def id_field_definitions(self, model: type[DeclarativeBase]) -> list[GraphQLFieldDefinition]:

--- a/src/strawchemy/sqlalchemy/_scope.py
+++ b/src/strawchemy/sqlalchemy/_scope.py
@@ -485,7 +485,7 @@ class QueryScope(Generic[DeclarativeT]):
         return columns
 
     def literal_column(self, from_name: str, column_name: str) -> Label[Any]:
-        return literal_column(f"{from_name}.{column_name}").label(self._add_scope_id(column_name))
+        return literal_column(f"{(from_name)}.{column_name}").label(self._add_scope_id(column_name))
 
     def set_relation_alias(
         self,

--- a/src/strawchemy/sqlalchemy/_transpiler.py
+++ b/src/strawchemy/sqlalchemy/_transpiler.py
@@ -706,7 +706,7 @@ class QueryTranspiler(Generic[DeclarativeT]):
             query.order_by = self._order_by(query_graph.order_by_nodes, query.joins)
             query.joins.extend(query.order_by.joins)
             if distinct_on_rank:
-                query.where = Where.from_expressions(subquery_builder.distinct_on_condition())
+                query.where = Where.from_expressions(subquery_builder.distinct_on_condition(subquery_alias))
             elif query.where:
                 query.where.clear_expressions()
         else:

--- a/src/strawchemy/sqlalchemy/inspector.py
+++ b/src/strawchemy/sqlalchemy/inspector.py
@@ -17,13 +17,12 @@ from strawchemy.strawberry.filters import (
     DateTimeComparison,
     EqualityComparison,
     GraphQLComparison,
-    JSONComparison,
     OrderComparison,
-    SQLITEJSONComparison,
     TextComparison,
     TimeComparison,
     TimeDeltaComparison,
 )
+from strawchemy.strawberry.filters.inputs import make_full_json_comparison_input, make_sqlite_json_comparison_input
 
 if TYPE_CHECKING:
     from strawchemy.dto.base import DTOFieldDefinition
@@ -47,7 +46,6 @@ _DEFAULT_FILTERS_MAP: FilterMap = OrderedDict(
         (bool,): EqualityComparison,
         (int, float, Decimal): OrderComparison,
         (str,): TextComparison,
-        (dict,): JSONComparison,
     }
 )
 
@@ -79,7 +77,9 @@ class SQLAlchemyGraphQLInspector(SQLAlchemyInspector):
 
             filters_map |= {(Geometry, WKBElement, WKTElement): GeoComparison}
         if self.db_features.dialect == "sqlite":
-            filters_map[(dict,)] = SQLITEJSONComparison
+            filters_map[(dict,)] = make_sqlite_json_comparison_input()
+        else:
+            filters_map[(dict,)] = make_full_json_comparison_input()
         return filters_map
 
     @classmethod

--- a/src/strawchemy/sqlalchemy/repository/_async.py
+++ b/src/strawchemy/sqlalchemy/repository/_async.py
@@ -3,17 +3,19 @@ from __future__ import annotations
 from collections import defaultdict, namedtuple
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypeAlias, TypeVar
 
-from sqlalchemy import ColumnElement, Row, and_, delete, insert, inspect, select, update
+from sqlalchemy import ColumnElement, Row, and_, delete, inspect, select, update
 from sqlalchemy.orm import RelationshipProperty
 from strawchemy.sqlalchemy._executor import AsyncQueryExecutor, QueryResult
 from strawchemy.sqlalchemy._transpiler import QueryTranspiler
 from strawchemy.sqlalchemy.typing import AnyAsyncSession, DeclarativeT
+from strawchemy.strawberry.mutation.input import UpsertData
 from strawchemy.strawberry.mutation.types import RelationType
 
-from ._base import SQLAlchemyGraphQLRepository
+from ._base import InsertData, SQLAlchemyGraphQLRepository
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from enum import Enum
 
     from sqlalchemy.orm import DeclarativeBase
     from sqlalchemy.orm.util import AliasedClass
@@ -27,28 +29,30 @@ __all__ = ("SQLAlchemyGraphQLAsyncRepository",)
 T = TypeVar("T", bound=Any)
 
 _RowLike: TypeAlias = "Row[Any] | NamedTuple"
-_InsertOrUpdate: TypeAlias = Literal["insert", "update_by_pks", "update_where"]
+_InsertOrUpdate: TypeAlias = Literal["insert", "update_by_pks", "update_where", "upsert"]
 
 
 class SQLAlchemyGraphQLAsyncRepository(SQLAlchemyGraphQLRepository[DeclarativeT, AnyAsyncSession]):
-    async def _insert_many(self, model_type: type[DeclarativeBase], values: list[dict[str, Any]]) -> Sequence[Row[Any]]:
-        if self._dialect.insert_executemany_returning_sort_by_parameter_order:
+    async def _insert_many(self, data: InsertData) -> Sequence[Row[Any]]:
+        if self._dialect.insert_executemany_returning_sort_by_parameter_order and not (
+            self._dialect.name == "postgresql" and data.is_upsert
+        ):
             results = await self.session.execute(
-                insert(model_type).returning(*model_type.__mapper__.primary_key, sort_by_parameter_order=True),
-                values,
+                self._insert_statement(data).returning(
+                    *data.model_type.__mapper__.primary_key, sort_by_parameter_order=True
+                ),
+                data.values,
             )
             return results.all()
         rows: Sequence[Row[Any]] = []
         conn = await self.session.connection()
-        for value in values:
-            cursor = await conn.execute(insert(model_type).values(**value))
+        for value in data.values:
+            cursor = await conn.execute(self._insert_statement(data).values(**value))
             assert cursor.inserted_primary_key is not None
             rows.append(cursor.inserted_primary_key)
         return rows
 
-    async def _insert_nested(
-        self, model_type: type[DeclarativeBase], values: list[dict[str, Any]], level: LevelInput
-    ) -> None:
+    async def _insert_nested(self, data: InsertData, level: LevelInput) -> None:
         """Inserts multiple records for a given model type and updates related instances.
 
         This internal method performs a bulk insert operation for the specified
@@ -59,23 +63,22 @@ class SQLAlchemyGraphQLAsyncRepository(SQLAlchemyGraphQLRepository[DeclarativeT,
         relationships where applicable.
 
         Args:
-            model_type: The SQLAlchemy declarative base class to insert records for.
-            values: A list of dictionaries, where each dictionary represents the
-                data for a single record to be inserted.
+            data: An InsertData object containing the model type, values to insert,
+                and optional upsert configuration for handling conflicts.
             level: The input level containing information about the instances being
                 created and their relationships, used to update instances with
                 generated primary and foreign keys.
         """
-        instance_ids: Sequence[Row[Any]] = await self._insert_many(model_type, values)
+        instance_ids: Sequence[Row[Any]] = await self._insert_many(data)
 
-        pk_names = [pk.name for pk in model_type.__mapper__.primary_key]
+        pk_names = [pk.name for pk in data.model_type.__mapper__.primary_key]
 
         pk_index, fk_index = 0, 0
         for relation_input in level.inputs:
-            if not isinstance(relation_input.instance, model_type):
+            if not isinstance(relation_input.instance, data.model_type):
                 continue
             # Update Pks
-            for column in model_type.__mapper__.primary_key:
+            for column in data.model_type.__mapper__.primary_key:
                 setattr(relation_input.instance, column.key, instance_ids[pk_index][pk_names.index(column.key)])
             pk_index += 1
             if relation_input.relation.relation_type is RelationType.TO_MANY:
@@ -148,14 +151,17 @@ class SQLAlchemyGraphQLAsyncRepository(SQLAlchemyGraphQLRepository[DeclarativeT,
             data: The processed input data containing nested structures and
                 relationship information.
         """
-        for level in data.filter_by_level(RelationType.TO_ONE, ["create"]):
+        for level in data.filter_by_level(RelationType.TO_ONE, ["create", "upsert"]):
             insert_params: defaultdict[type[DeclarativeBase], list[dict[str, Any]]] = defaultdict(list)
+            upsert_data_map: dict[type[DeclarativeBase], UpsertData] = {}
 
             for create_input in level.inputs:
                 insert_params[create_input.relation.related].append(self._to_dict(create_input.instance))
+                if create_input.relation.upsert is not None:
+                    upsert_data_map[create_input.relation.related] = create_input.relation.upsert
 
             for model_type, values in insert_params.items():
-                await self._insert_nested(model_type, values, level)
+                await self._insert_nested(InsertData(model_type, values, upsert_data_map.get(model_type)), level)
 
     async def _update_to_many_relations(self, data: Input[DeclarativeT], created_ids: Sequence[_RowLike]) -> None:
         """Updates foreign keys to connect existing related objects for to-many relationships.
@@ -267,8 +273,9 @@ class SQLAlchemyGraphQLAsyncRepository(SQLAlchemyGraphQLRepository[DeclarativeT,
                 of the main objects created in the parent operation. Used to set
                 foreign keys on the newly created related objects.
         """
-        for level in data.filter_by_level(RelationType.TO_MANY, ["create"]):
+        for level in data.filter_by_level(RelationType.TO_MANY, ["create", "upsert"]):
             insert_params: defaultdict[type[DeclarativeBase], list[dict[str, Any]]] = defaultdict(list)
+            upsert_data_map: dict[type[DeclarativeBase], UpsertData] = {}
             for create_input in level.inputs:
                 relation = create_input.relation
                 prop = relation.attribute
@@ -280,19 +287,32 @@ class SQLAlchemyGraphQLAsyncRepository(SQLAlchemyGraphQLRepository[DeclarativeT,
                     if local.key and remote.key
                 }
                 insert_params[relation.related].append(self._to_dict(create_input.instance) | fks)
+                if create_input.relation.upsert is not None:
+                    upsert_data_map[create_input.relation.related] = create_input.relation.upsert
 
             for model_type, values in insert_params.items():
-                await self._insert_nested(model_type, values, level)
+                await self._insert_nested(InsertData(model_type, values, upsert_data_map.get(model_type)), level)
 
     async def _execute_insert_or_update(
         self,
         mode: _InsertOrUpdate,
         data: Input[DeclarativeT],
         dto_filter: BooleanFilterDTO | None,
+        upsert_update_fields: list[EnumDTO] | None = None,
+        upsert_confict_constraint: Enum | None = None,
     ) -> Sequence[_RowLike]:
         values = [self._to_dict(instance) for instance in data.instances]
         if mode == "insert":
-            return await self._insert_many(self.model, values)
+            return await self._insert_many(InsertData(self.model, values))
+
+        if mode == "upsert":
+            return await self._insert_many(
+                InsertData(
+                    self.model,
+                    values,
+                    UpsertData(update_fields=upsert_update_fields or [], conflict_constraint=upsert_confict_constraint),
+                )
+            )
 
         pks = [column.key for column in self.model.__mapper__.primary_key]
         pk_tuple = namedtuple("AsRow", pks)  # pyright: ignore[reportUntypedNamedTuple]  # noqa: PYI024
@@ -310,12 +330,13 @@ class SQLAlchemyGraphQLAsyncRepository(SQLAlchemyGraphQLRepository[DeclarativeT,
         mode: _InsertOrUpdate,
         data: Input[DeclarativeT],
         dto_filter: BooleanFilterDTO | None = None,
+        upsert_update_fields: list[EnumDTO] | None = None,
     ) -> Sequence[_RowLike]:
         self._connect_to_one_relations(data)
         data.add_non_input_relations()
         async with self.session.begin_nested() as transaction:
             await self._create_nested_to_one_relations(data)
-            instance_ids = await self._execute_insert_or_update(mode, data, dto_filter)
+            instance_ids = await self._execute_insert_or_update(mode, data, dto_filter, upsert_update_fields)
             await self._create_to_many_relations(data, instance_ids)
             await self._update_to_many_relations(data, instance_ids)
             await self._set_to_many_relations(mode, data, instance_ids)
@@ -508,6 +529,16 @@ class SQLAlchemyGraphQLAsyncRepository(SQLAlchemyGraphQLRepository[DeclarativeT,
             according to the selection.
         """
         created_ids = await self._mutate("insert", data)
+        return await self._list_by_ids(created_ids, selection)
+
+    async def upsert(
+        self,
+        data: Input[DeclarativeT],
+        selection: QueryNodeType | None = None,
+        update_fields: list[EnumDTO] | None = None,
+        dto_filter: BooleanFilterDTO | None = None,
+    ) -> QueryResult[DeclarativeT]:
+        created_ids = await self._mutate("upsert", data, dto_filter=dto_filter, upsert_update_fields=update_fields)
         return await self._list_by_ids(created_ids, selection)
 
     async def update_by_ids(

--- a/src/strawchemy/sqlalchemy/repository/_base.py
+++ b/src/strawchemy/sqlalchemy/repository/_base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeAlias, TypeVar
 
 from sqlalchemy import Column, Function, Insert, Row, func, insert
 from sqlalchemy.dialects import mysql, postgresql, sqlite
@@ -31,6 +31,7 @@ __all__ = ("SQLAlchemyGraphQLRepository",)
 
 
 T = TypeVar("T", bound=Any)
+InsertOrUpdate: TypeAlias = Literal["insert", "update_by_pks", "update_where", "upsert"]
 
 
 @dataclass(frozen=True)
@@ -75,6 +76,15 @@ class InsertData:
         ):
             update_fields = {auto_increment_pk_column: func.last_insert_id(auto_increment_pk_column)} | update_fields
         return update_fields
+
+
+@dataclass(frozen=True)
+class MutationData(Generic[DeclarativeT]):
+    mode: InsertOrUpdate
+    input: Input[DeclarativeT]
+    dto_filter: BooleanFilterDTO | None = None
+    upsert_update_fields: list[EnumDTO] | None = None
+    upsert_conflict_fields: EnumDTO | None = None
 
 
 class SQLAlchemyGraphQLRepository(Generic[DeclarativeT, SessionT]):

--- a/src/strawchemy/sqlalchemy/repository/_base.py
+++ b/src/strawchemy/sqlalchemy/repository/_base.py
@@ -1,30 +1,80 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
-from sqlalchemy import Row, inspect
-from sqlalchemy.orm import NO_VALUE, RelationshipProperty
+from sqlalchemy import Column, Function, Insert, Row, func, insert
+from sqlalchemy.dialects import mysql, postgresql, sqlite
+from sqlalchemy.orm import RelationshipProperty
 from strawchemy.dto.inspectors.sqlalchemy import SQLAlchemyInspector
+from strawchemy.exceptions import StrawchemyError
 from strawchemy.sqlalchemy._transpiler import QueryTranspiler
 from strawchemy.sqlalchemy.typing import DeclarativeT, QueryExecutorT, SessionT
 from strawchemy.strawberry.mutation.types import RelationType
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
 
     from sqlalchemy import Select
     from sqlalchemy.orm import DeclarativeBase
+    from sqlalchemy.sql.base import ReadOnlyColumnCollection
+    from sqlalchemy.sql.elements import KeyedColumnElement
     from strawchemy.sqlalchemy.hook import QueryHook
     from strawchemy.strawberry.dto import BooleanFilterDTO, EnumDTO, OrderByDTO
-    from strawchemy.strawberry.mutation.input import Input
+    from strawchemy.strawberry.mutation.input import Input, UpsertData
     from strawchemy.strawberry.typing import QueryNodeType
+    from strawchemy.typing import SupportedDialect
 
 
 __all__ = ("SQLAlchemyGraphQLRepository",)
 
 
 T = TypeVar("T", bound=Any)
+
+
+@dataclass(frozen=True)
+class InsertData:
+    model_type: type[DeclarativeBase]
+    values: list[dict[str, Any]]
+    upsert_data: UpsertData | None = None
+
+    @property
+    def is_upsert(self) -> bool:
+        return self.upsert_data is not None
+
+    @property
+    def upsert_data_or_raise(self) -> UpsertData:
+        if self.upsert_data is None:
+            msg = "UpsertData is required"
+            raise StrawchemyError(msg)
+        return self.upsert_data
+
+    def conflict_target_columns(self) -> list[Column[Any]]:
+        if self.upsert_data_or_raise.conflict_constraint:
+            return list(self.upsert_data_or_raise.conflict_constraint.value.columns)
+        return list(self.model_type.__mapper__.primary_key)
+
+    def upsert_set(
+        self, dialect: SupportedDialect, columns: ReadOnlyColumnCollection[str, KeyedColumnElement[Any]]
+    ) -> Mapping[Column[Any], KeyedColumnElement[Any] | Function[Any]]:
+        update_fields_set = {
+            dto_field.field_definition.model_field_name for dto_field in self.upsert_data_or_raise.update_fields
+        } or {name for value_dict in self.values for name in value_dict}
+        mapper = self.model_type.__mapper__
+        update_fields = {mapper.columns[name]: value for name, value in columns.items() if name in update_fields_set}
+        if (
+            dialect == "mysql"
+            and (
+                auto_increment_pk_column := next(
+                    (column for column in self.model_type.__mapper__.primary_key if column.autoincrement),
+                    None,
+                )
+            )
+            is not None
+        ):
+            update_fields = {auto_increment_pk_column: func.last_insert_id(auto_increment_pk_column)} | update_fields
+        return update_fields
 
 
 class SQLAlchemyGraphQLRepository(Generic[DeclarativeT, SessionT]):
@@ -76,9 +126,28 @@ class SQLAlchemyGraphQLRepository(Generic[DeclarativeT, SessionT]):
             execution_options=execution_options if execution_options is not None else self.execution_options,
         )
 
-    @classmethod
-    def _loaded_attributes(cls, model: DeclarativeBase) -> set[str]:
-        return {name for name, attr in inspect(model).attrs.items() if attr.loaded_value is not NO_VALUE}
+    def _insert_statement(self, data: InsertData) -> Insert:
+        if not data.is_upsert:
+            return insert(data.model_type)
+        if self._dialect.name == "postgresql":
+            statement = postgresql.insert(data.model_type)
+            statement = statement.on_conflict_do_update(
+                set_=data.upsert_set(self._dialect.name, statement.excluded),
+                index_elements=data.conflict_target_columns(),
+            )
+        elif self._dialect.name == "sqlite":
+            statement = sqlite.insert(data.model_type)
+            statement = statement.on_conflict_do_update(
+                set_=data.upsert_set(self._dialect.name, statement.excluded),
+                index_elements=data.conflict_target_columns(),
+            )
+        elif self._dialect.name == "mysql":
+            statement = mysql.insert(data.model_type)
+            statement = statement.on_duplicate_key_update(data.upsert_set(self._dialect.name, statement.inserted))
+        else:
+            msg = f"This dialect does not support upsert statements: {self._dialect.name}"
+            raise StrawchemyError(msg)
+        return statement
 
     def _to_dict(self, model: DeclarativeBase) -> dict[str, Any]:
         return {

--- a/src/strawchemy/strawberry/_field.py
+++ b/src/strawchemy/strawberry/_field.py
@@ -27,7 +27,16 @@ from strawberry.types import get_object_definition
 from strawberry.types.arguments import StrawberryArgument
 from strawberry.types.base import StrawberryList, StrawberryOptional, StrawberryType, WithStrawberryObjectDefinition
 from strawberry.types.field import UNRESOLVED, StrawberryField
-from strawchemy.constants import DATA_KEY, DISTINCT_ON_KEY, FILTER_KEY, LIMIT_KEY, NODES_KEY, OFFSET_KEY, ORDER_BY_KEY
+from strawchemy.constants import (
+    DATA_KEY,
+    DISTINCT_ON_KEY,
+    FILTER_KEY,
+    LIMIT_KEY,
+    NODES_KEY,
+    OFFSET_KEY,
+    ORDER_BY_KEY,
+    UPSERT_UPDATE_FIELDS,
+)
 from strawchemy.dto.base import MappedDTO
 from strawchemy.dto.types import DTOConfig, Purpose
 from strawchemy.strawberry.dto import (
@@ -531,6 +540,58 @@ class StrawchemyCreateMutationField(_StrawchemyInputMutationField, _StrawchemyMu
         self, info: Info[Any, Any], *args: Any, **kwargs: Any
     ) -> _CreateOrUpdateResolverResult | Coroutine[_CreateOrUpdateResolverResult, Any, Any]:
         return self._create_resolver(info, *args, **kwargs)
+
+
+class StrawchemyUpsertMutationField(_StrawchemyInputMutationField, _StrawchemyMutationField):
+    def __init__(
+        self,
+        input_type: type[MappedGraphQLDTO[T]],
+        update_fields_enum: type[EnumDTO],
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(input_type, *args, **kwargs)
+        self._update_fields_enum = update_fields_enum
+
+    def _upsert_resolver(
+        self,
+        info: Info,
+        data: AnyMappedDTO | Sequence[AnyMappedDTO],
+        filter_input: BooleanFilterDTO | None = None,
+        update_fields: list[EnumDTO] | None = None,
+    ) -> _CreateOrUpdateResolverResult | Coroutine[_CreateOrUpdateResolverResult, Any, Any]:
+        repository = self._get_repository(info)
+        try:
+            input_data = Input(data, self._validation)
+        except InputValidationError as error:
+            return error.graphql_type()
+        if isinstance(repository, StrawchemyAsyncRepository):
+            return self._input_result_async(repository.upsert(input_data, filter_input, update_fields), input_data)
+        return self._input_result_sync(repository.upsert(input_data, filter_input, update_fields), input_data)
+
+    @override
+    def auto_arguments(self) -> list[StrawberryArgument]:
+        arguments = [
+            StrawberryArgument(
+                UPSERT_UPDATE_FIELDS,
+                None,
+                type_annotation=StrawberryAnnotation(list[self._update_fields_enum] | None),
+                default=None,
+            )
+        ]
+        if self.is_list:
+            arguments.append(
+                StrawberryArgument(DATA_KEY, None, type_annotation=StrawberryAnnotation(list[self._input_type]))
+            )
+        else:
+            arguments.append(StrawberryArgument(DATA_KEY, None, type_annotation=StrawberryAnnotation(self._input_type)))
+        return arguments
+
+    @override
+    def resolver(
+        self, info: Info[Any, Any], *args: Any, **kwargs: Any
+    ) -> _CreateOrUpdateResolverResult | Coroutine[_CreateOrUpdateResolverResult, Any, Any]:
+        return self._upsert_resolver(info, *args, **kwargs)
 
 
 class StrawchemyUpdateMutationField(_StrawchemyInputMutationField, _StrawchemyMutationField):

--- a/src/strawchemy/strawberry/factories/enum.py
+++ b/src/strawchemy/strawberry/factories/enum.py
@@ -1,17 +1,3 @@
-"""This module defines factories for creating GraphQL DTOs (Data Transfer Objects).
-
-It includes factories for:
-- Aggregate DTOs
-- Aggregate Filter DTOs
-- OrderBy DTOs
-- Type DTOs
-- Filter DTOs
-- Enum DTOs
-
-These factories are used to generate DTOs that are compatible with GraphQL schemas,
-allowing for efficient data transfer and filtering in GraphQL queries.
-"""
-
 from __future__ import annotations
 
 from collections.abc import Iterable
@@ -20,14 +6,7 @@ from types import new_class
 from typing import TYPE_CHECKING, Any, TypeVar, cast, override
 
 from sqlalchemy.orm import DeclarativeBase, QueryableAttribute
-from strawchemy.dto.base import (
-    DTOBackend,
-    DTOBase,
-    DTOFactory,
-    DTOFieldDefinition,
-    ModelInspector,
-    Relation,
-)
+from strawchemy.dto.base import DTOBackend, DTOBase, DTOFactory, DTOFieldDefinition, ModelInspector, Relation
 from strawchemy.dto.types import DTOConfig, ExcludeFields, IncludeFields, Purpose
 from strawchemy.strawberry.dto import EnumDTO, GraphQLFieldDefinition
 from strawchemy.utils import snake_to_lower_camel_case
@@ -138,6 +117,29 @@ class EnumDTOFactory(DTOFactory[DeclarativeBase, QueryableAttribute[Any], EnumDT
         return super().decorator(
             model,
             purpose,
+            include=include,
+            exclude=exclude,
+            partial=partial,
+            aliases=aliases,
+            alias_generator=alias_generator,
+            type_map=type_map,
+            **kwargs,
+        )
+
+    def input(
+        self,
+        model: type[DeclarativeBase],
+        include: IncludeFields | None = None,
+        exclude: ExcludeFields | None = None,
+        partial: bool | None = None,
+        type_map: Mapping[Any, Any] | None = None,
+        aliases: Mapping[str, str] | None = None,
+        alias_generator: Callable[[str], str] | None = None,
+        **kwargs: Any,
+    ) -> Callable[[type[Any]], type[EnumDTO]]:
+        return super().decorator(
+            model,
+            Purpose.WRITE,
             include=include,
             exclude=exclude,
             partial=partial,

--- a/src/strawchemy/strawberry/factories/enum.py
+++ b/src/strawchemy/strawberry/factories/enum.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from enum import Enum
 from inspect import getmodule
 from types import new_class
 from typing import TYPE_CHECKING, Any, TypeVar, cast, override
 
 from sqlalchemy.orm import DeclarativeBase, QueryableAttribute
-from strawchemy.dto.base import DTOBackend, DTOBase, DTOFactory, DTOFieldDefinition, ModelInspector, Relation
+from strawchemy.dto.base import DTOBackend, DTOBase, DTOFactory, DTOFieldDefinition, Relation
 from strawchemy.dto.types import DTOConfig, ExcludeFields, IncludeFields, Purpose
 from strawchemy.strawberry.dto import EnumDTO, GraphQLFieldDefinition
 from strawchemy.utils import snake_to_lower_camel_case
@@ -15,6 +16,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Generator, Iterable, Mapping
 
     from strawchemy.graph import Node
+    from strawchemy.sqlalchemy.inspector import SQLAlchemyGraphQLInspector
 
 T = TypeVar("T")
 
@@ -28,14 +30,16 @@ class EnumDTOBackend(DTOBackend[EnumDTO]):
     def build(
         self,
         name: str,
-        model: type[T],
+        model: type[DeclarativeBase],
         field_definitions: Iterable[DTOFieldDefinition[DeclarativeBase, QueryableAttribute[Any]]],
         base: type[Any] | None = None,
+        values: Iterable[Any] | None = None,
         **kwargs: Any,
     ) -> type[EnumDTO]:
         field_map = {
             snake_to_lower_camel_case(field.name) if self.to_camel else field.name: field for field in field_definitions
         }
+        values = list(values or []) or field_map.keys()
 
         def exec_body(namespace: dict[str, Any]) -> Any:
             def to_field_definition(self: EnumDTO) -> DTOFieldDefinition[DeclarativeBase, QueryableAttribute[Any]]:
@@ -50,7 +54,7 @@ class EnumDTOBackend(DTOBackend[EnumDTO]):
             module = model_module.__name__
         return cast(
             "type[EnumDTO]",
-            EnumDTO(value=name, names=[(value, value) for value in list(field_map)], type=base, module=module),
+            EnumDTO(value=name, names=list(zip(list(field_map), values, strict=True)), type=base, module=module),
         )
 
     @override
@@ -61,10 +65,41 @@ class EnumDTOBackend(DTOBackend[EnumDTO]):
         return enum
 
 
+class UpsertConflictFieldsEnumDTOBackend(EnumDTOBackend):
+    def __init__(self, inspector: SQLAlchemyGraphQLInspector, to_camel: bool = True) -> None:
+        self.dto_base = EnumDTO
+        self.to_camel = to_camel
+        self._inspector = inspector
+
+    @override
+    def build(
+        self,
+        name: str,
+        model: type[DeclarativeBase],
+        field_definitions: Iterable[DTOFieldDefinition[DeclarativeBase, QueryableAttribute[Any]]],
+        base: type[Any] | None = None,
+        values: Iterable[Any] | None = None,
+        **kwargs: Any,
+    ) -> type[EnumDTO]:
+        constraint_columns = self._inspector.unique_constraints(model)
+        constraint_map = {column.key: constraint for constraint in constraint_columns for column in constraint.columns}
+        field_definitions = list(field_definitions)
+        return super().build(
+            name,
+            model,
+            field_definitions,
+            base,
+            [constraint_map[field.model_field_name] for field in field_definitions],
+            **kwargs,
+        )
+
+
 class EnumDTOFactory(DTOFactory[DeclarativeBase, QueryableAttribute[Any], EnumDTO]):
+    inspector: SQLAlchemyGraphQLInspector
+
     def __init__(
         self,
-        inspector: ModelInspector[Any, QueryableAttribute[Any]],
+        inspector: SQLAlchemyGraphQLInspector,
         backend: DTOBackend[EnumDTO] | None = None,
         handle_cycles: bool = True,
         type_map: dict[Any, Any] | None = None,
@@ -147,4 +182,21 @@ class EnumDTOFactory(DTOFactory[DeclarativeBase, QueryableAttribute[Any], EnumDT
             alias_generator=alias_generator,
             type_map=type_map,
             **kwargs,
+        )
+
+    def upsert_conflict_fields(
+        self,
+        model: type[DeclarativeBase],
+        name: str | None = None,
+    ) -> type[Enum]:
+        name = name or f"{model.__name__}ConflictFields"
+        return cast(
+            "type[Enum]",
+            Enum(
+                name,
+                [
+                    (f"{'_'.join(col.key for col in constraint.columns)}", constraint)
+                    for constraint in self.inspector.unique_constraints(model)
+                ],
+            ),
         )

--- a/src/strawchemy/strawberry/factories/types.py
+++ b/src/strawchemy/strawberry/factories/types.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import dataclasses
 from collections.abc import Generator
-from typing import TYPE_CHECKING, Any, Self, TypeVar, override
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast, override
 
 from sqlalchemy import JSON
 from sqlalchemy.orm import DeclarativeBase
@@ -36,7 +37,7 @@ from strawchemy.utils import non_optional_type_hint, snake_to_camel
 
 from .aggregations import AggregationInspector
 from .base import GraphQLDTOFactory, MappedGraphQLDTOT, StrawchemyMappedFactory, _ChildOptions
-from .enum import EnumDTOFactory
+from .enum import EnumDTOBackend, EnumDTOFactory
 from .inputs import OrderByDTOFactory
 
 if TYPE_CHECKING:
@@ -404,6 +405,7 @@ class InputFactory(TypeDTOFactory[MappedGraphQLDTOT]):
         super().__init__(mapper, backend, handle_cycles, type_map, **kwargs)
         self._identifier_input_dto_builder = StrawberrryDTOBackend(MappedStrawberryGraphQLDTO[DeclarativeBase])
         self._identifier_input_dto_factory = DTOFactory(self.inspector, self.backend)
+        self._upsert_fields_enum_factory = EnumDTOFactory(self.inspector, EnumDTOBackend())
 
     def _identifier_input(
         self,
@@ -428,7 +430,41 @@ class InputFactory(TypeDTOFactory[MappedGraphQLDTOT]):
                 )
                 raise EmptyDTOError(msg) from error
 
-        return self._register_type(base, dto_config, node, description="Identifier input")
+        return self._register_type(base, dto_config, node, description="Identifier input", user_defined=False)
+
+    def _upsert_udpate_fields(
+        self,
+        field: DTOFieldDefinition[DeclarativeBase, QueryableAttribute[Any]],
+        node: Node[Relation[DeclarativeBase, MappedGraphQLDTOT], None],
+        dto_config: DTOConfig,
+    ) -> type[EnumDTO]:
+        name = f"{node.root.value.model.__name__}{snake_to_camel(field.name)}UpdateFields"
+        related_model = field.related_model
+        assert related_model
+        update_fields = self._upsert_fields_enum_factory.factory(
+            related_model, dataclasses.replace(dto_config, purpose=Purpose.WRITE), name=name
+        )
+        return self._mapper.registry.register_enum(update_fields, name=name, description="Update fields enum")
+
+    def _upsert_conflict_fields(
+        self,
+        field: DTOFieldDefinition[DeclarativeBase, QueryableAttribute[Any]],
+        node: Node[Relation[DeclarativeBase, MappedGraphQLDTOT], None],
+        dto_config: DTOConfig,
+    ) -> type[Enum]:
+        name = f"{node.root.value.model.__name__}{snake_to_camel(field.name)}ConflictFields"
+        related_model = field.related_model
+        assert related_model
+        conflict_fields = Enum(
+            name,
+            [
+                (f"{'_'.join(col.key for col in constraint.columns)}", constraint)
+                for constraint in self.inspector.unique_constraints(related_model)
+            ],
+        )
+        return self._mapper.registry.register_enum(
+            cast("type[Enum]", conflict_fields), name=name, description="Update fields enum"
+        )
 
     @override
     def _cache_key(
@@ -489,19 +525,28 @@ class InputFactory(TypeDTOFactory[MappedGraphQLDTOT]):
         self._resolve_relation_type(field, dto_config, node, mode=mode, **factory_kwargs)
         identifier_input = self._identifier_input(field, node)
         field_required = self.inspector.required(field.model_field)
+        upsert_update_fields = self._upsert_udpate_fields(field, node, dto_config)
+        upsert_conflict_fields = self._upsert_conflict_fields(field, node, dto_config)
+
         if field.uselist:
             if mode == "create":
-                input_type = ToManyCreateInput[identifier_input, field.related_dto]  # pyright: ignore[reportInvalidTypeArguments]
+                input_type = ToManyCreateInput[
+                    identifier_input, field.related_dto, upsert_update_fields, upsert_conflict_fields  # pyright: ignore[reportInvalidTypeArguments]
+                ]
             else:
                 type_ = (
                     RequiredToManyUpdateInput
                     if self.inspector.reverse_relation_required(field.model_field)
                     else ToManyUpdateInput
                 )
-                input_type = type_[identifier_input, field.related_dto]  # pyright: ignore[reportInvalidTypeArguments]
+                input_type = type_[  # pyright: ignore[reportInvalidTypeArguments]
+                    identifier_input, field.related_dto, upsert_update_fields, upsert_conflict_fields
+                ]
         else:
             type_ = RequiredToOneInput if field_required else ToOneInput
-            input_type = type_[identifier_input, field.related_dto]  # pyright: ignore[reportInvalidTypeArguments]
+            input_type = type_[  # pyright: ignore[reportInvalidTypeArguments]
+                identifier_input, field.related_dto, upsert_update_fields, upsert_conflict_fields
+            ]
         return input_type if field_required and mode == "create" else input_type | None
 
     @override

--- a/src/strawchemy/strawberry/factories/types.py
+++ b/src/strawchemy/strawberry/factories/types.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 import dataclasses
 from collections.abc import Generator
-from enum import Enum
-from typing import TYPE_CHECKING, Any, Self, TypeVar, cast, override
+from typing import TYPE_CHECKING, Any, Self, TypeVar, override
 
 from sqlalchemy import JSON
-from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy.orm import DeclarativeBase, QueryableAttribute
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.types.arguments import StrawberryArgument
 from strawchemy.constants import AGGREGATIONS_KEY, JSON_PATH_KEY, NODES_KEY
@@ -37,16 +36,17 @@ from strawchemy.utils import non_optional_type_hint, snake_to_camel
 
 from .aggregations import AggregationInspector
 from .base import GraphQLDTOFactory, MappedGraphQLDTOT, StrawchemyMappedFactory, _ChildOptions
-from .enum import EnumDTOBackend, EnumDTOFactory
+from .enum import EnumDTOFactory, UpsertConflictFieldsEnumDTOBackend
 from .inputs import OrderByDTOFactory
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Hashable, Sequence
+    from enum import Enum
 
-    from sqlalchemy.orm import QueryableAttribute
     from strawchemy import Strawchemy
     from strawchemy.dto.base import DTOBackend, DTOBase, DTOFieldDefinition, Relation
     from strawchemy.graph import Node
+    from strawchemy.sqlalchemy.inspector import SQLAlchemyGraphQLInspector
     from strawchemy.sqlalchemy.typing import DeclarativeT
     from strawchemy.types import DefaultOffsetPagination
 
@@ -393,6 +393,43 @@ class DistinctOnFieldsDTOFactory(EnumDTOFactory):
         return f"{base_name}DistinctOnFields"
 
 
+class UpsertConflictFieldsDTOFactory(EnumDTOFactory):
+    inspector: SQLAlchemyGraphQLInspector
+
+    def __init__(
+        self,
+        inspector: SQLAlchemyGraphQLInspector,
+        backend: UpsertConflictFieldsEnumDTOBackend | None = None,
+        handle_cycles: bool = True,
+        type_map: dict[Any, Any] | None = None,
+    ) -> None:
+        super().__init__(inspector, backend or UpsertConflictFieldsEnumDTOBackend(inspector), handle_cycles, type_map)
+
+    @override
+    def dto_name(
+        self, base_name: str, dto_config: DTOConfig, node: Node[Relation[Any, EnumDTO], None] | None = None
+    ) -> str:
+        return f"{base_name}ConflictFields"
+
+    @override
+    def should_exclude_field(
+        self,
+        field: DTOFieldDefinition[DeclarativeBase, QueryableAttribute[Any]],
+        dto_config: DTOConfig,
+        node: Node[Relation[Any, EnumDTO], None],
+        has_override: bool,
+    ) -> bool:
+        constraint_columns = {
+            column for constraint in self.inspector.unique_constraints(field.model) for column in constraint.columns
+        }
+        columns = field.model.__mapper__.column_attrs
+        return (
+            super().should_exclude_field(field, dto_config, node, has_override)
+            or field.model_field_name not in columns
+            or any(column not in constraint_columns for column in columns[field.model_field_name].columns)
+        )
+
+
 class InputFactory(TypeDTOFactory[MappedGraphQLDTOT]):
     def __init__(
         self,
@@ -405,7 +442,8 @@ class InputFactory(TypeDTOFactory[MappedGraphQLDTOT]):
         super().__init__(mapper, backend, handle_cycles, type_map, **kwargs)
         self._identifier_input_dto_builder = StrawberrryDTOBackend(MappedStrawberryGraphQLDTO[DeclarativeBase])
         self._identifier_input_dto_factory = DTOFactory(self.inspector, self.backend)
-        self._upsert_fields_enum_factory = EnumDTOFactory(self.inspector, EnumDTOBackend())
+        self._upsert_update_fields_enum_factory = EnumDTOFactory(self.inspector)
+        self._upsert_conflict_fields_enum_factory = UpsertConflictFieldsDTOFactory(self.inspector)
 
     def _identifier_input(
         self,
@@ -441,7 +479,7 @@ class InputFactory(TypeDTOFactory[MappedGraphQLDTOT]):
         name = f"{node.root.value.model.__name__}{snake_to_camel(field.name)}UpdateFields"
         related_model = field.related_model
         assert related_model
-        update_fields = self._upsert_fields_enum_factory.factory(
+        update_fields = self._upsert_update_fields_enum_factory.factory(
             related_model, dataclasses.replace(dto_config, purpose=Purpose.WRITE), name=name
         )
         return self._mapper.registry.register_enum(update_fields, name=name, description="Update fields enum")
@@ -455,16 +493,10 @@ class InputFactory(TypeDTOFactory[MappedGraphQLDTOT]):
         name = f"{node.root.value.model.__name__}{snake_to_camel(field.name)}ConflictFields"
         related_model = field.related_model
         assert related_model
-        conflict_fields = Enum(
-            name,
-            [
-                (f"{'_'.join(col.key for col in constraint.columns)}", constraint)
-                for constraint in self.inspector.unique_constraints(related_model)
-            ],
+        conflict_fields = self._upsert_conflict_fields_enum_factory.factory(
+            related_model, dataclasses.replace(dto_config, purpose=Purpose.WRITE), name=name
         )
-        return self._mapper.registry.register_enum(
-            cast("type[Enum]", conflict_fields), name=name, description="Update fields enum"
-        )
+        return self._mapper.registry.register_enum(conflict_fields, name=name, description="Conflict fields enum")
 
     @override
     def _cache_key(

--- a/src/strawchemy/strawberry/filters/__init__.py
+++ b/src/strawchemy/strawberry/filters/__init__.py
@@ -8,12 +8,12 @@ from .inputs import (
     GraphQLComparison,
     GraphQLComparisonT,
     GraphQLFilter,
-    JSONComparison,
     OrderComparison,
-    SQLITEJSONComparison,
     TextComparison,
     TimeComparison,
     TimeDeltaComparison,
+    _JSONComparison,
+    _SQLiteJSONComparison,
 )
 
 __all__ = (
@@ -24,10 +24,10 @@ __all__ = (
     "GraphQLComparison",
     "GraphQLComparisonT",
     "GraphQLFilter",
-    "JSONComparison",
     "OrderComparison",
-    "SQLITEJSONComparison",
     "TextComparison",
     "TimeComparison",
     "TimeDeltaComparison",
+    "_JSONComparison",
+    "_SQLiteJSONComparison",
 )

--- a/src/strawchemy/strawberry/filters/base.py
+++ b/src/strawchemy/strawberry/filters/base.py
@@ -20,11 +20,11 @@ if TYPE_CHECKING:
         DateTimeComparison,
         EqualityComparison,
         GraphQLComparison,
-        JSONComparison,
         OrderComparison,
         TextComparison,
         TimeComparison,
         TimeDeltaComparison,
+        _JSONComparison,
     )
 
 
@@ -157,7 +157,7 @@ class TextFilter(OrderFilter):
 
 @dataclass(frozen=True)
 class JSONFilter(EqualityFilter):
-    comparison: JSONComparison
+    comparison: _JSONComparison
 
     def _postgres_json(
         self, model_attribute: ColumnElement[JSON] | QueryableAttribute[JSON]

--- a/src/strawchemy/strawberry/repository/_async.py
+++ b/src/strawchemy/strawberry/repository/_async.py
@@ -114,8 +114,11 @@ class StrawchemyAsyncRepository(StrawchemyRepository[T]):
         data: Input[InputModel],
         filter_input: BooleanFilterDTO | None = None,
         update_fields: list[EnumDTO] | None = None,
+        conflict_fields: EnumDTO | None = None,
     ) -> GraphQLResult[InputModel, T]:
-        query_results = await self.graphql_repository().upsert(data, self._tree, update_fields, filter_input)
+        query_results = await self.graphql_repository().upsert(
+            data, self._tree, update_fields, conflict_fields, filter_input
+        )
         return GraphQLResult(query_results, self._tree)
 
     async def update_by_id(self, data: Input[InputModel]) -> GraphQLResult[InputModel, T]:

--- a/src/strawchemy/strawberry/repository/_async.py
+++ b/src/strawchemy/strawberry/repository/_async.py
@@ -109,6 +109,15 @@ class StrawchemyAsyncRepository(StrawchemyRepository[T]):
         query_results = await self.graphql_repository().create(data, self._tree)
         return GraphQLResult(query_results, self._tree)
 
+    async def upsert(
+        self,
+        data: Input[InputModel],
+        filter_input: BooleanFilterDTO | None = None,
+        update_fields: list[EnumDTO] | None = None,
+    ) -> GraphQLResult[InputModel, T]:
+        query_results = await self.graphql_repository().upsert(data, self._tree, update_fields, filter_input)
+        return GraphQLResult(query_results, self._tree)
+
     async def update_by_id(self, data: Input[InputModel]) -> GraphQLResult[InputModel, T]:
         query_results = await self.graphql_repository().update_by_ids(data, self._tree)
         return GraphQLResult(query_results, self._tree)

--- a/src/strawchemy/strawberry/repository/_sync.py
+++ b/src/strawchemy/strawberry/repository/_sync.py
@@ -116,8 +116,9 @@ class StrawchemySyncRepository(StrawchemyRepository[T]):
         data: Input[InputModel],
         filter_input: BooleanFilterDTO | None = None,
         update_fields: list[EnumDTO] | None = None,
+        conflict_fields: EnumDTO | None = None,
     ) -> GraphQLResult[InputModel, T]:
-        query_results = self.graphql_repository().upsert(data, self._tree, update_fields, filter_input)
+        query_results = self.graphql_repository().upsert(data, self._tree, update_fields, conflict_fields, filter_input)
         return GraphQLResult(query_results, self._tree)
 
     def update_by_id(self, data: Input[InputModel]) -> GraphQLResult[InputModel, T]:

--- a/src/strawchemy/strawberry/repository/_sync.py
+++ b/src/strawchemy/strawberry/repository/_sync.py
@@ -111,6 +111,15 @@ class StrawchemySyncRepository(StrawchemyRepository[T]):
         query_results = self.graphql_repository().create(data, self._tree)
         return GraphQLResult(query_results, self._tree)
 
+    def upsert(
+        self,
+        data: Input[InputModel],
+        filter_input: BooleanFilterDTO | None = None,
+        update_fields: list[EnumDTO] | None = None,
+    ) -> GraphQLResult[InputModel, T]:
+        query_results = self.graphql_repository().upsert(data, self._tree, update_fields, filter_input)
+        return GraphQLResult(query_results, self._tree)
+
     def update_by_id(self, data: Input[InputModel]) -> GraphQLResult[InputModel, T]:
         query_results = self.graphql_repository().update_by_ids(data, self._tree)
         return GraphQLResult(query_results, self._tree)

--- a/tests/integration/__snapshots__/test_distinct_on.ambr
+++ b/tests/integration/__snapshots__/test_distinct_on.ambr
@@ -1,116 +1,116 @@
 # serializer version: 1
 # name: test_distinct_and_order_by[session-tracked-async-aiosqlite_engine]
   '''
-  SELECT color.name,
-         color.id
+  SELECT user.name,
+         user.id
     FROM (
-          SELECT color.id AS id,
-                 color.name AS name,
-                 color.name AS name__1,
-                 color.id AS id__1,
-                 row_number() OVER (PARTITION BY color.name ORDER BY color.name ASC, color.id DESC) AS __strawchemy_distinct_on_rank_0
-            FROM color AS color
-           ORDER BY color.name ASC,
-                    color.id DESC
-         ) AS color
-   WHERE color.__strawchemy_distinct_on_rank_0 = ?
-   ORDER BY color.name ASC,
-            color.id DESC
+          SELECT user.id AS id,
+                 user.name AS name,
+                 user.name AS name__1,
+                 user.id AS id__1,
+                 row_number() OVER (PARTITION BY user.name ORDER BY user.name ASC, user.id DESC) AS __strawchemy_distinct_on_rank_0
+            FROM USER AS USER
+           ORDER BY user.name ASC,
+                    user.id DESC
+         ) AS USER
+   WHERE user.__strawchemy_distinct_on_rank_0 = ?
+   ORDER BY user.name ASC,
+            user.id DESC
   '''
 # ---
 # name: test_distinct_and_order_by[session-tracked-async-asyncmy_engine]
   '''
-  SELECT color.name,
-         color.id
+  SELECT user.name,
+         user.id
     FROM (
-          SELECT color.id AS id,
-                 color.name AS name,
-                 color.name AS name__1,
-                 color.id AS id__1,
-                 row_number() OVER (PARTITION BY color.name ORDER BY color.name ASC, color.id DESC) AS __strawchemy_distinct_on_rank_0
-            FROM color AS color
-           ORDER BY color.name ASC,
-                    color.id DESC
-         ) AS color
-   WHERE color.__strawchemy_distinct_on_rank_0 = %s
-   ORDER BY color.name ASC,
-            color.id DESC
+          SELECT user.id AS id,
+                 user.name AS name,
+                 user.name AS name__1,
+                 user.id AS id__1,
+                 row_number() OVER (PARTITION BY user.name ORDER BY user.name ASC, user.id DESC) AS __strawchemy_distinct_on_rank_0
+            FROM USER AS USER
+           ORDER BY user.name ASC,
+                    user.id DESC
+         ) AS USER
+   WHERE user.__strawchemy_distinct_on_rank_0 = %s
+   ORDER BY user.name ASC,
+            user.id DESC
   '''
 # ---
 # name: test_distinct_and_order_by[session-tracked-async-asyncpg_engine]
   '''
-  SELECT color.name,
-         color.id
+  SELECT "user".name,
+         "user".id
     FROM (
-          SELECT color.id AS id,
-                 color.name AS name,
-                 color.name AS name__1,
-                 color.id AS id__1,
-                 row_number() OVER (PARTITION BY color.name ORDER BY color.name ASC, color.id DESC) AS __strawchemy_distinct_on_rank_0
-            FROM color AS color
-           ORDER BY color.name ASC,
-                    color.id DESC
-         ) AS color
-   WHERE color.__strawchemy_distinct_on_rank_0 = $1::INTEGER
-   ORDER BY color.name ASC,
-            color.id DESC
+          SELECT "user".id AS id,
+                 "user".name AS name,
+                 "user".name AS name__1,
+                 "user".id AS id__1,
+                 row_number() OVER (PARTITION BY "user".name ORDER BY "user".name ASC, "user".id DESC) AS __strawchemy_distinct_on_rank_0
+            FROM "user" AS "user"
+           ORDER BY "user".name ASC,
+                    "user".id DESC
+         ) AS "user"
+   WHERE "user".__strawchemy_distinct_on_rank_0 = $1::INTEGER
+   ORDER BY "user".name ASC,
+            "user".id DESC
   '''
 # ---
 # name: test_distinct_and_order_by[session-tracked-async-psycopg_async_engine]
   '''
-  SELECT color.name,
-         color.id
+  SELECT "user".name,
+         "user".id
     FROM (
-          SELECT color.id AS id,
-                 color.name AS name,
-                 color.name AS name__1,
-                 color.id AS id__1,
-                 row_number() OVER (PARTITION BY color.name ORDER BY color.name ASC, color.id DESC) AS __strawchemy_distinct_on_rank_0
-            FROM color AS color
-           ORDER BY color.name ASC,
-                    color.id DESC
-         ) AS color
-   WHERE color.__strawchemy_distinct_on_rank_0 = %(param_1)s::INTEGER
-   ORDER BY color.name ASC,
-            color.id DESC
+          SELECT "user".id AS id,
+                 "user".name AS name,
+                 "user".name AS name__1,
+                 "user".id AS id__1,
+                 row_number() OVER (PARTITION BY "user".name ORDER BY "user".name ASC, "user".id DESC) AS __strawchemy_distinct_on_rank_0
+            FROM "user" AS "user"
+           ORDER BY "user".name ASC,
+                    "user".id DESC
+         ) AS "user"
+   WHERE "user".__strawchemy_distinct_on_rank_0 = %(strawchemy_distinct_on_rank_0_1)s::INTEGER
+   ORDER BY "user".name ASC,
+            "user".id DESC
   '''
 # ---
 # name: test_distinct_and_order_by[session-tracked-sync-psycopg_engine]
   '''
-  SELECT color.name,
-         color.id
+  SELECT "user".name,
+         "user".id
     FROM (
-          SELECT color.id AS id,
-                 color.name AS name,
-                 color.name AS name__1,
-                 color.id AS id__1,
-                 row_number() OVER (PARTITION BY color.name ORDER BY color.name ASC, color.id DESC) AS __strawchemy_distinct_on_rank_0
-            FROM color AS color
-           ORDER BY color.name ASC,
-                    color.id DESC
-         ) AS color
-   WHERE color.__strawchemy_distinct_on_rank_0 = %(param_1)s::INTEGER
-   ORDER BY color.name ASC,
-            color.id DESC
+          SELECT "user".id AS id,
+                 "user".name AS name,
+                 "user".name AS name__1,
+                 "user".id AS id__1,
+                 row_number() OVER (PARTITION BY "user".name ORDER BY "user".name ASC, "user".id DESC) AS __strawchemy_distinct_on_rank_0
+            FROM "user" AS "user"
+           ORDER BY "user".name ASC,
+                    "user".id DESC
+         ) AS "user"
+   WHERE "user".__strawchemy_distinct_on_rank_0 = %(strawchemy_distinct_on_rank_0_1)s::INTEGER
+   ORDER BY "user".name ASC,
+            "user".id DESC
   '''
 # ---
 # name: test_distinct_and_order_by[session-tracked-sync-sqlite_engine]
   '''
-  SELECT color.name,
-         color.id
+  SELECT user.name,
+         user.id
     FROM (
-          SELECT color.id AS id,
-                 color.name AS name,
-                 color.name AS name__1,
-                 color.id AS id__1,
-                 row_number() OVER (PARTITION BY color.name ORDER BY color.name ASC, color.id DESC) AS __strawchemy_distinct_on_rank_0
-            FROM color AS color
-           ORDER BY color.name ASC,
-                    color.id DESC
-         ) AS color
-   WHERE color.__strawchemy_distinct_on_rank_0 = ?
-   ORDER BY color.name ASC,
-            color.id DESC
+          SELECT user.id AS id,
+                 user.name AS name,
+                 user.name AS name__1,
+                 user.id AS id__1,
+                 row_number() OVER (PARTITION BY user.name ORDER BY user.name ASC, user.id DESC) AS __strawchemy_distinct_on_rank_0
+            FROM USER AS USER
+           ORDER BY user.name ASC,
+                    user.id DESC
+         ) AS USER
+   WHERE user.__strawchemy_distinct_on_rank_0 = ?
+   ORDER BY user.name ASC,
+            user.id DESC
   '''
 # ---
 # name: test_distinct_on[session-tracked-async-asyncmy_engine]
@@ -145,104 +145,104 @@
 # ---
 # name: test_distinct_on[session-tracked-async-deterministic-ordering-aiosqlite_engine]
   '''
-  SELECT color.name,
-         color.id
+  SELECT user.name,
+         user.id
     FROM (
-          SELECT color.id AS id,
-                 color.name AS name,
-                 row_number() OVER (PARTITION BY color.name ORDER BY color.id ASC) AS __strawchemy_distinct_on_rank_0
-            FROM color AS color
-           ORDER BY color.id ASC
-         ) AS color
-   WHERE color.__strawchemy_distinct_on_rank_0 = ?
-   ORDER BY color.id ASC
+          SELECT user.id AS id,
+                 user.name AS name,
+                 row_number() OVER (PARTITION BY user.name ORDER BY user.id ASC) AS __strawchemy_distinct_on_rank_0
+            FROM USER AS USER
+           ORDER BY user.id ASC
+         ) AS USER
+   WHERE user.__strawchemy_distinct_on_rank_0 = ?
+   ORDER BY user.id ASC
   '''
 # ---
 # name: test_distinct_on[session-tracked-async-deterministic-ordering-asyncmy_engine]
   '''
-  SELECT color.name,
-         color.id
+  SELECT user.name,
+         user.id
     FROM (
-          SELECT color.id AS id,
-                 color.name AS name,
-                 row_number() OVER (PARTITION BY color.name ORDER BY color.id ASC) AS __strawchemy_distinct_on_rank_0
-            FROM color AS color
-           ORDER BY color.id ASC
-         ) AS color
-   WHERE color.__strawchemy_distinct_on_rank_0 = %s
-   ORDER BY color.id ASC
+          SELECT user.id AS id,
+                 user.name AS name,
+                 row_number() OVER (PARTITION BY user.name ORDER BY user.id ASC) AS __strawchemy_distinct_on_rank_0
+            FROM USER AS USER
+           ORDER BY user.id ASC
+         ) AS USER
+   WHERE user.__strawchemy_distinct_on_rank_0 = %s
+   ORDER BY user.id ASC
   '''
 # ---
 # name: test_distinct_on[session-tracked-async-deterministic-ordering-asyncpg_engine]
   '''
-  SELECT color.name,
-         color.id
+  SELECT "user".name,
+         "user".id
     FROM (
-          SELECT color.id AS id,
-                 color.name AS name,
-                 row_number() OVER (PARTITION BY color.name ORDER BY color.id ASC) AS __strawchemy_distinct_on_rank_0
-            FROM color AS color
-           ORDER BY color.id ASC
-         ) AS color
-   WHERE color.__strawchemy_distinct_on_rank_0 = $1::INTEGER
-   ORDER BY color.id ASC
+          SELECT "user".id AS id,
+                 "user".name AS name,
+                 row_number() OVER (PARTITION BY "user".name ORDER BY "user".id ASC) AS __strawchemy_distinct_on_rank_0
+            FROM "user" AS "user"
+           ORDER BY "user".id ASC
+         ) AS "user"
+   WHERE "user".__strawchemy_distinct_on_rank_0 = $1::INTEGER
+   ORDER BY "user".id ASC
   '''
 # ---
 # name: test_distinct_on[session-tracked-async-deterministic-ordering-psycopg_async_engine]
   '''
-  SELECT color.name,
-         color.id
+  SELECT "user".name,
+         "user".id
     FROM (
-          SELECT color.id AS id,
-                 color.name AS name,
-                 row_number() OVER (PARTITION BY color.name ORDER BY color.id ASC) AS __strawchemy_distinct_on_rank_0
-            FROM color AS color
-           ORDER BY color.id ASC
-         ) AS color
-   WHERE color.__strawchemy_distinct_on_rank_0 = %(param_1)s::INTEGER
-   ORDER BY color.id ASC
+          SELECT "user".id AS id,
+                 "user".name AS name,
+                 row_number() OVER (PARTITION BY "user".name ORDER BY "user".id ASC) AS __strawchemy_distinct_on_rank_0
+            FROM "user" AS "user"
+           ORDER BY "user".id ASC
+         ) AS "user"
+   WHERE "user".__strawchemy_distinct_on_rank_0 = %(strawchemy_distinct_on_rank_0_1)s::INTEGER
+   ORDER BY "user".id ASC
   '''
 # ---
 # name: test_distinct_on[session-tracked-async-non-deterministic-ordering-aiosqlite_engine]
   '''
-  SELECT color.name,
-         color.id
+  SELECT user.name,
+         user.id
     FROM (
-          SELECT color.id AS id,
-                 color.name AS name,
-                 row_number() OVER (PARTITION BY color.name) AS __strawchemy_distinct_on_rank_0
-            FROM color AS color
-         ) AS color
-   WHERE color.__strawchemy_distinct_on_rank_0 = ?
+          SELECT user.id AS id,
+                 user.name AS name,
+                 row_number() OVER (PARTITION BY user.name) AS __strawchemy_distinct_on_rank_0
+            FROM USER AS USER
+         ) AS USER
+   WHERE user.__strawchemy_distinct_on_rank_0 = ?
   '''
 # ---
 # name: test_distinct_on[session-tracked-async-non-deterministic-ordering-asyncmy_engine]
   '''
-  SELECT color.name,
-         color.id
+  SELECT user.name,
+         user.id
     FROM (
-          SELECT color.id AS id,
-                 color.name AS name,
-                 row_number() OVER (PARTITION BY color.name) AS __strawchemy_distinct_on_rank_0
-            FROM color AS color
-         ) AS color
-   WHERE color.__strawchemy_distinct_on_rank_0 = %s
+          SELECT user.id AS id,
+                 user.name AS name,
+                 row_number() OVER (PARTITION BY user.name) AS __strawchemy_distinct_on_rank_0
+            FROM USER AS USER
+         ) AS USER
+   WHERE user.__strawchemy_distinct_on_rank_0 = %s
   '''
 # ---
 # name: test_distinct_on[session-tracked-async-non-deterministic-ordering-asyncpg_engine]
   '''
   SELECT DISTINCT
-      ON (color.name) color.name,
-         color.id
-    FROM color AS color
+      ON ("user".name) "user".name,
+         "user".id
+    FROM "user" AS "user"
   '''
 # ---
 # name: test_distinct_on[session-tracked-async-non-deterministic-ordering-psycopg_async_engine]
   '''
   SELECT DISTINCT
-      ON (color.name) color.name,
-         color.id
-    FROM color AS color
+      ON ("user".name) "user".name,
+         "user".id
+    FROM "user" AS "user"
   '''
 # ---
 # name: test_distinct_on[session-tracked-async-psycopg_async_engine]
@@ -262,53 +262,53 @@
 # ---
 # name: test_distinct_on[session-tracked-sync-deterministic-ordering-psycopg_engine]
   '''
-  SELECT color.name,
-         color.id
+  SELECT "user".name,
+         "user".id
     FROM (
-          SELECT color.id AS id,
-                 color.name AS name,
-                 row_number() OVER (PARTITION BY color.name ORDER BY color.id ASC) AS __strawchemy_distinct_on_rank_0
-            FROM color AS color
-           ORDER BY color.id ASC
-         ) AS color
-   WHERE color.__strawchemy_distinct_on_rank_0 = %(param_1)s::INTEGER
-   ORDER BY color.id ASC
+          SELECT "user".id AS id,
+                 "user".name AS name,
+                 row_number() OVER (PARTITION BY "user".name ORDER BY "user".id ASC) AS __strawchemy_distinct_on_rank_0
+            FROM "user" AS "user"
+           ORDER BY "user".id ASC
+         ) AS "user"
+   WHERE "user".__strawchemy_distinct_on_rank_0 = %(strawchemy_distinct_on_rank_0_1)s::INTEGER
+   ORDER BY "user".id ASC
   '''
 # ---
 # name: test_distinct_on[session-tracked-sync-deterministic-ordering-sqlite_engine]
   '''
-  SELECT color.name,
-         color.id
+  SELECT user.name,
+         user.id
     FROM (
-          SELECT color.id AS id,
-                 color.name AS name,
-                 row_number() OVER (PARTITION BY color.name ORDER BY color.id ASC) AS __strawchemy_distinct_on_rank_0
-            FROM color AS color
-           ORDER BY color.id ASC
-         ) AS color
-   WHERE color.__strawchemy_distinct_on_rank_0 = ?
-   ORDER BY color.id ASC
+          SELECT user.id AS id,
+                 user.name AS name,
+                 row_number() OVER (PARTITION BY user.name ORDER BY user.id ASC) AS __strawchemy_distinct_on_rank_0
+            FROM USER AS USER
+           ORDER BY user.id ASC
+         ) AS USER
+   WHERE user.__strawchemy_distinct_on_rank_0 = ?
+   ORDER BY user.id ASC
   '''
 # ---
 # name: test_distinct_on[session-tracked-sync-non-deterministic-ordering-psycopg_engine]
   '''
   SELECT DISTINCT
-      ON (color.name) color.name,
-         color.id
-    FROM color AS color
+      ON ("user".name) "user".name,
+         "user".id
+    FROM "user" AS "user"
   '''
 # ---
 # name: test_distinct_on[session-tracked-sync-non-deterministic-ordering-sqlite_engine]
   '''
-  SELECT color.name,
-         color.id
+  SELECT user.name,
+         user.id
     FROM (
-          SELECT color.id AS id,
-                 color.name AS name,
-                 row_number() OVER (PARTITION BY color.name) AS __strawchemy_distinct_on_rank_0
-            FROM color AS color
-         ) AS color
-   WHERE color.__strawchemy_distinct_on_rank_0 = ?
+          SELECT user.id AS id,
+                 user.name AS name,
+                 row_number() OVER (PARTITION BY user.name) AS __strawchemy_distinct_on_rank_0
+            FROM USER AS USER
+         ) AS USER
+   WHERE user.__strawchemy_distinct_on_rank_0 = ?
   '''
 # ---
 # name: test_distinct_on[session-tracked-sync-psycopg_engine]

--- a/tests/integration/__snapshots__/test_upsert.ambr
+++ b/tests/integration/__snapshots__/test_upsert.ambr
@@ -1,0 +1,1194 @@
+# serializer version: 1
+# name: test_to_many_upsert_create_new[session-tracked-async-aiosqlite_engine]
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING id
+  '''
+# ---
+# name: test_to_many_upsert_create_new[session-tracked-async-aiosqlite_engine].1
+  '''
+  UPDATE color
+     SET name = ?,
+         updated_at = ?
+   WHERE color.id = ?
+  '''
+# ---
+# name: test_to_many_upsert_create_new[session-tracked-async-aiosqlite_engine].2
+  '''
+  SELECT color__fruits.name,
+         color__fruits.id,
+         color.name AS name_1,
+         color.id AS id_1
+    FROM color AS color
+    LEFT OUTER JOIN fruit AS color__fruits
+      ON color.id = color__fruits.color_id
+   WHERE color.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY color.id ASC,
+            color__fruits.id ASC
+  '''
+# ---
+# name: test_to_many_upsert_create_new[session-tracked-async-asyncmy_engine]
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (%s, %s, %s, %s, %s, %s, %s) AS NEW
+      ON DUPLICATE KEY UPDATE name = new.name,
+         color_id = new.color_id,
+         sweetness = new.sweetness,
+         water_percent = new.water_percent,
+         best_time_to_pick = new.best_time_to_pick,
+         id = last_insert_id(fruit.id)
+  '''
+# ---
+# name: test_to_many_upsert_create_new[session-tracked-async-asyncmy_engine].1
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (%s, %s, %s, %s, %s, %s, %s) AS NEW
+      ON DUPLICATE KEY UPDATE name = new.name,
+         color_id = new.color_id,
+         sweetness = new.sweetness,
+         water_percent = new.water_percent,
+         best_time_to_pick = new.best_time_to_pick,
+         id = last_insert_id(fruit.id)
+  '''
+# ---
+# name: test_to_many_upsert_create_new[session-tracked-async-asyncmy_engine].2
+  '''
+  UPDATE color
+     SET name = %s,
+         updated_at = %s
+   WHERE color.id = %s
+  '''
+# ---
+# name: test_to_many_upsert_create_new[session-tracked-async-asyncmy_engine].3
+  '''
+  SELECT color__fruits.name,
+         color__fruits.id,
+         color.name AS name_1,
+         color.id AS id_1
+    FROM color AS color
+    LEFT OUTER JOIN fruit AS color__fruits
+      ON color.id = color__fruits.color_id
+   WHERE color.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY color.id ASC,
+            color__fruits.id ASC
+  '''
+# ---
+# name: test_to_many_upsert_create_new[session-tracked-async-asyncpg_engine]
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES ($1::VARCHAR, $2::INTEGER, $3::INTEGER, $4::FLOAT, $5::TIME WITHOUT TIME ZONE, $6::TIMESTAMP WITHOUT TIME ZONE, $7::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_to_many_upsert_create_new[session-tracked-async-asyncpg_engine].1
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES ($1::VARCHAR, $2::INTEGER, $3::INTEGER, $4::FLOAT, $5::TIME WITHOUT TIME ZONE, $6::TIMESTAMP WITHOUT TIME ZONE, $7::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_to_many_upsert_create_new[session-tracked-async-asyncpg_engine].2
+  '''
+  UPDATE color
+     SET name = $1::VARCHAR,
+         updated_at = $2::TIMESTAMP WITHOUT TIME
+    ZONE
+   WHERE color.id = $3::INTEGER
+  '''
+# ---
+# name: test_to_many_upsert_create_new[session-tracked-async-asyncpg_engine].3
+  '''
+  SELECT color__fruits.name,
+         color__fruits.id,
+         color.name AS name_1,
+         color.id AS id_1
+    FROM color AS color
+    LEFT OUTER JOIN fruit AS color__fruits
+      ON color.id = color__fruits.color_id
+   WHERE color.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY color.id ASC,
+            color__fruits.id ASC
+  '''
+# ---
+# name: test_to_many_upsert_create_new[session-tracked-async-psycopg_async_engine]
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(color_id)s::INTEGER, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_to_many_upsert_create_new[session-tracked-async-psycopg_async_engine].1
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(color_id)s::INTEGER, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_to_many_upsert_create_new[session-tracked-async-psycopg_async_engine].2
+  '''
+  UPDATE color
+     SET name = %(name)s::VARCHAR,
+         updated_at = %(updated_at)s::TIMESTAMP WITHOUT TIME
+    ZONE
+   WHERE color.id = %(color_id)s::INTEGER
+  '''
+# ---
+# name: test_to_many_upsert_create_new[session-tracked-async-psycopg_async_engine].3
+  '''
+  SELECT color__fruits.name,
+         color__fruits.id,
+         color.name AS name_1,
+         color.id AS id_1
+    FROM color AS color
+    LEFT OUTER JOIN fruit AS color__fruits
+      ON color.id = color__fruits.color_id
+   WHERE color.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY color.id ASC,
+            color__fruits.id ASC
+  '''
+# ---
+# name: test_to_many_upsert_create_new[session-tracked-sync-psycopg_engine]
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(color_id)s::INTEGER, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_to_many_upsert_create_new[session-tracked-sync-psycopg_engine].1
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(color_id)s::INTEGER, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_to_many_upsert_create_new[session-tracked-sync-psycopg_engine].2
+  '''
+  UPDATE color
+     SET name = %(name)s::VARCHAR,
+         updated_at = %(updated_at)s::TIMESTAMP WITHOUT TIME
+    ZONE
+   WHERE color.id = %(color_id)s::INTEGER
+  '''
+# ---
+# name: test_to_many_upsert_create_new[session-tracked-sync-psycopg_engine].3
+  '''
+  SELECT color__fruits.name,
+         color__fruits.id,
+         color.name AS name_1,
+         color.id AS id_1
+    FROM color AS color
+    LEFT OUTER JOIN fruit AS color__fruits
+      ON color.id = color__fruits.color_id
+   WHERE color.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY color.id ASC,
+            color__fruits.id ASC
+  '''
+# ---
+# name: test_to_many_upsert_create_new[session-tracked-sync-sqlite_engine]
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING id
+  '''
+# ---
+# name: test_to_many_upsert_create_new[session-tracked-sync-sqlite_engine].1
+  '''
+  UPDATE color
+     SET name = ?,
+         updated_at = ?
+   WHERE color.id = ?
+  '''
+# ---
+# name: test_to_many_upsert_create_new[session-tracked-sync-sqlite_engine].2
+  '''
+  SELECT color__fruits.name,
+         color__fruits.id,
+         color.name AS name_1,
+         color.id AS id_1
+    FROM color AS color
+    LEFT OUTER JOIN fruit AS color__fruits
+      ON color.id = color__fruits.color_id
+   WHERE color.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY color.id ASC,
+            color__fruits.id ASC
+  '''
+# ---
+# name: test_to_many_upsert_mixed_create_and_update[session-tracked-async-aiosqlite_engine]
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING id
+  '''
+# ---
+# name: test_to_many_upsert_mixed_create_and_update[session-tracked-async-aiosqlite_engine].1
+  '''
+  UPDATE color
+     SET name = ?,
+         updated_at = ?
+   WHERE color.id = ?
+  '''
+# ---
+# name: test_to_many_upsert_mixed_create_and_update[session-tracked-async-aiosqlite_engine].2
+  '''
+  SELECT color__fruits.name,
+         color__fruits.id,
+         color.name AS name_1,
+         color.id AS id_1
+    FROM color AS color
+    LEFT OUTER JOIN fruit AS color__fruits
+      ON color.id = color__fruits.color_id
+   WHERE color.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY color.id ASC,
+            color__fruits.id ASC
+  '''
+# ---
+# name: test_to_many_upsert_mixed_create_and_update[session-tracked-async-asyncmy_engine]
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (%s, %s, %s, %s, %s, %s, %s) AS NEW
+      ON DUPLICATE KEY UPDATE name = new.name,
+         color_id = new.color_id,
+         sweetness = new.sweetness,
+         water_percent = new.water_percent,
+         best_time_to_pick = new.best_time_to_pick,
+         id = last_insert_id(fruit.id)
+  '''
+# ---
+# name: test_to_many_upsert_mixed_create_and_update[session-tracked-async-asyncmy_engine].1
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (%s, %s, %s, %s, %s, %s, %s) AS NEW
+      ON DUPLICATE KEY UPDATE name = new.name,
+         color_id = new.color_id,
+         sweetness = new.sweetness,
+         water_percent = new.water_percent,
+         best_time_to_pick = new.best_time_to_pick,
+         id = last_insert_id(fruit.id)
+  '''
+# ---
+# name: test_to_many_upsert_mixed_create_and_update[session-tracked-async-asyncmy_engine].2
+  '''
+  UPDATE color
+     SET name = %s,
+         updated_at = %s
+   WHERE color.id = %s
+  '''
+# ---
+# name: test_to_many_upsert_mixed_create_and_update[session-tracked-async-asyncmy_engine].3
+  '''
+  SELECT color__fruits.name,
+         color__fruits.id,
+         color.name AS name_1,
+         color.id AS id_1
+    FROM color AS color
+    LEFT OUTER JOIN fruit AS color__fruits
+      ON color.id = color__fruits.color_id
+   WHERE color.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY color.id ASC,
+            color__fruits.id ASC
+  '''
+# ---
+# name: test_to_many_upsert_mixed_create_and_update[session-tracked-async-asyncpg_engine]
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES ($1::VARCHAR, $2::INTEGER, $3::INTEGER, $4::FLOAT, $5::TIME WITHOUT TIME ZONE, $6::TIMESTAMP WITHOUT TIME ZONE, $7::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_to_many_upsert_mixed_create_and_update[session-tracked-async-asyncpg_engine].1
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES ($1::VARCHAR, $2::INTEGER, $3::INTEGER, $4::FLOAT, $5::TIME WITHOUT TIME ZONE, $6::TIMESTAMP WITHOUT TIME ZONE, $7::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_to_many_upsert_mixed_create_and_update[session-tracked-async-asyncpg_engine].2
+  '''
+  UPDATE color
+     SET name = $1::VARCHAR,
+         updated_at = $2::TIMESTAMP WITHOUT TIME
+    ZONE
+   WHERE color.id = $3::INTEGER
+  '''
+# ---
+# name: test_to_many_upsert_mixed_create_and_update[session-tracked-async-asyncpg_engine].3
+  '''
+  SELECT color__fruits.name,
+         color__fruits.id,
+         color.name AS name_1,
+         color.id AS id_1
+    FROM color AS color
+    LEFT OUTER JOIN fruit AS color__fruits
+      ON color.id = color__fruits.color_id
+   WHERE color.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY color.id ASC,
+            color__fruits.id ASC
+  '''
+# ---
+# name: test_to_many_upsert_mixed_create_and_update[session-tracked-async-psycopg_async_engine]
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(color_id)s::INTEGER, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_to_many_upsert_mixed_create_and_update[session-tracked-async-psycopg_async_engine].1
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(color_id)s::INTEGER, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_to_many_upsert_mixed_create_and_update[session-tracked-async-psycopg_async_engine].2
+  '''
+  UPDATE color
+     SET name = %(name)s::VARCHAR,
+         updated_at = %(updated_at)s::TIMESTAMP WITHOUT TIME
+    ZONE
+   WHERE color.id = %(color_id)s::INTEGER
+  '''
+# ---
+# name: test_to_many_upsert_mixed_create_and_update[session-tracked-async-psycopg_async_engine].3
+  '''
+  SELECT color__fruits.name,
+         color__fruits.id,
+         color.name AS name_1,
+         color.id AS id_1
+    FROM color AS color
+    LEFT OUTER JOIN fruit AS color__fruits
+      ON color.id = color__fruits.color_id
+   WHERE color.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY color.id ASC,
+            color__fruits.id ASC
+  '''
+# ---
+# name: test_to_many_upsert_mixed_create_and_update[session-tracked-sync-psycopg_engine]
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(color_id)s::INTEGER, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_to_many_upsert_mixed_create_and_update[session-tracked-sync-psycopg_engine].1
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(color_id)s::INTEGER, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_to_many_upsert_mixed_create_and_update[session-tracked-sync-psycopg_engine].2
+  '''
+  UPDATE color
+     SET name = %(name)s::VARCHAR,
+         updated_at = %(updated_at)s::TIMESTAMP WITHOUT TIME
+    ZONE
+   WHERE color.id = %(color_id)s::INTEGER
+  '''
+# ---
+# name: test_to_many_upsert_mixed_create_and_update[session-tracked-sync-psycopg_engine].3
+  '''
+  SELECT color__fruits.name,
+         color__fruits.id,
+         color.name AS name_1,
+         color.id AS id_1
+    FROM color AS color
+    LEFT OUTER JOIN fruit AS color__fruits
+      ON color.id = color__fruits.color_id
+   WHERE color.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY color.id ASC,
+            color__fruits.id ASC
+  '''
+# ---
+# name: test_to_many_upsert_mixed_create_and_update[session-tracked-sync-sqlite_engine]
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING id
+  '''
+# ---
+# name: test_to_many_upsert_mixed_create_and_update[session-tracked-sync-sqlite_engine].1
+  '''
+  UPDATE color
+     SET name = ?,
+         updated_at = ?
+   WHERE color.id = ?
+  '''
+# ---
+# name: test_to_many_upsert_mixed_create_and_update[session-tracked-sync-sqlite_engine].2
+  '''
+  SELECT color__fruits.name,
+         color__fruits.id,
+         color.name AS name_1,
+         color.id AS id_1
+    FROM color AS color
+    LEFT OUTER JOIN fruit AS color__fruits
+      ON color.id = color__fruits.color_id
+   WHERE color.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY color.id ASC,
+            color__fruits.id ASC
+  '''
+# ---
+# name: test_to_many_upsert_update_existing[session-tracked-async-aiosqlite_engine]
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING id
+  '''
+# ---
+# name: test_to_many_upsert_update_existing[session-tracked-async-aiosqlite_engine].1
+  '''
+  UPDATE color
+     SET name = ?,
+         updated_at = ?
+   WHERE color.id = ?
+  '''
+# ---
+# name: test_to_many_upsert_update_existing[session-tracked-async-aiosqlite_engine].2
+  '''
+  SELECT color__fruits.name,
+         color__fruits.id,
+         color.name AS name_1,
+         color.id AS id_1
+    FROM color AS color
+    LEFT OUTER JOIN fruit AS color__fruits
+      ON color.id = color__fruits.color_id
+   WHERE color.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY color.id ASC,
+            color__fruits.id ASC
+  '''
+# ---
+# name: test_to_many_upsert_update_existing[session-tracked-async-asyncmy_engine]
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (%s, %s, %s, %s, %s, %s, %s) AS NEW
+      ON DUPLICATE KEY UPDATE name = new.name,
+         color_id = new.color_id,
+         sweetness = new.sweetness,
+         water_percent = new.water_percent,
+         best_time_to_pick = new.best_time_to_pick,
+         id = last_insert_id(fruit.id)
+  '''
+# ---
+# name: test_to_many_upsert_update_existing[session-tracked-async-asyncmy_engine].1
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (%s, %s, %s, %s, %s, %s, %s) AS NEW
+      ON DUPLICATE KEY UPDATE name = new.name,
+         color_id = new.color_id,
+         sweetness = new.sweetness,
+         water_percent = new.water_percent,
+         best_time_to_pick = new.best_time_to_pick,
+         id = last_insert_id(fruit.id)
+  '''
+# ---
+# name: test_to_many_upsert_update_existing[session-tracked-async-asyncmy_engine].2
+  '''
+  UPDATE color
+     SET name = %s,
+         updated_at = %s
+   WHERE color.id = %s
+  '''
+# ---
+# name: test_to_many_upsert_update_existing[session-tracked-async-asyncmy_engine].3
+  '''
+  SELECT color__fruits.name,
+         color__fruits.id,
+         color.name AS name_1,
+         color.id AS id_1
+    FROM color AS color
+    LEFT OUTER JOIN fruit AS color__fruits
+      ON color.id = color__fruits.color_id
+   WHERE color.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY color.id ASC,
+            color__fruits.id ASC
+  '''
+# ---
+# name: test_to_many_upsert_update_existing[session-tracked-async-asyncpg_engine]
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES ($1::VARCHAR, $2::INTEGER, $3::INTEGER, $4::FLOAT, $5::TIME WITHOUT TIME ZONE, $6::TIMESTAMP WITHOUT TIME ZONE, $7::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_to_many_upsert_update_existing[session-tracked-async-asyncpg_engine].1
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES ($1::VARCHAR, $2::INTEGER, $3::INTEGER, $4::FLOAT, $5::TIME WITHOUT TIME ZONE, $6::TIMESTAMP WITHOUT TIME ZONE, $7::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_to_many_upsert_update_existing[session-tracked-async-asyncpg_engine].2
+  '''
+  UPDATE color
+     SET name = $1::VARCHAR,
+         updated_at = $2::TIMESTAMP WITHOUT TIME
+    ZONE
+   WHERE color.id = $3::INTEGER
+  '''
+# ---
+# name: test_to_many_upsert_update_existing[session-tracked-async-asyncpg_engine].3
+  '''
+  SELECT color__fruits.name,
+         color__fruits.id,
+         color.name AS name_1,
+         color.id AS id_1
+    FROM color AS color
+    LEFT OUTER JOIN fruit AS color__fruits
+      ON color.id = color__fruits.color_id
+   WHERE color.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY color.id ASC,
+            color__fruits.id ASC
+  '''
+# ---
+# name: test_to_many_upsert_update_existing[session-tracked-async-psycopg_async_engine]
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(color_id)s::INTEGER, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_to_many_upsert_update_existing[session-tracked-async-psycopg_async_engine].1
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(color_id)s::INTEGER, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_to_many_upsert_update_existing[session-tracked-async-psycopg_async_engine].2
+  '''
+  UPDATE color
+     SET name = %(name)s::VARCHAR,
+         updated_at = %(updated_at)s::TIMESTAMP WITHOUT TIME
+    ZONE
+   WHERE color.id = %(color_id)s::INTEGER
+  '''
+# ---
+# name: test_to_many_upsert_update_existing[session-tracked-async-psycopg_async_engine].3
+  '''
+  SELECT color__fruits.name,
+         color__fruits.id,
+         color.name AS name_1,
+         color.id AS id_1
+    FROM color AS color
+    LEFT OUTER JOIN fruit AS color__fruits
+      ON color.id = color__fruits.color_id
+   WHERE color.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY color.id ASC,
+            color__fruits.id ASC
+  '''
+# ---
+# name: test_to_many_upsert_update_existing[session-tracked-sync-psycopg_engine]
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(color_id)s::INTEGER, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_to_many_upsert_update_existing[session-tracked-sync-psycopg_engine].1
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(color_id)s::INTEGER, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_to_many_upsert_update_existing[session-tracked-sync-psycopg_engine].2
+  '''
+  UPDATE color
+     SET name = %(name)s::VARCHAR,
+         updated_at = %(updated_at)s::TIMESTAMP WITHOUT TIME
+    ZONE
+   WHERE color.id = %(color_id)s::INTEGER
+  '''
+# ---
+# name: test_to_many_upsert_update_existing[session-tracked-sync-psycopg_engine].3
+  '''
+  SELECT color__fruits.name,
+         color__fruits.id,
+         color.name AS name_1,
+         color.id AS id_1
+    FROM color AS color
+    LEFT OUTER JOIN fruit AS color__fruits
+      ON color.id = color__fruits.color_id
+   WHERE color.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY color.id ASC,
+            color__fruits.id ASC
+  '''
+# ---
+# name: test_to_many_upsert_update_existing[session-tracked-sync-sqlite_engine]
+  '''
+  INSERT INTO fruit (name, color_id, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         color_id = excluded.color_id,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING id
+  '''
+# ---
+# name: test_to_many_upsert_update_existing[session-tracked-sync-sqlite_engine].1
+  '''
+  UPDATE color
+     SET name = ?,
+         updated_at = ?
+   WHERE color.id = ?
+  '''
+# ---
+# name: test_to_many_upsert_update_existing[session-tracked-sync-sqlite_engine].2
+  '''
+  SELECT color__fruits.name,
+         color__fruits.id,
+         color.name AS name_1,
+         color.id AS id_1
+    FROM color AS color
+    LEFT OUTER JOIN fruit AS color__fruits
+      ON color.id = color__fruits.color_id
+   WHERE color.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY color.id ASC,
+            color__fruits.id ASC
+  '''
+# ---
+# name: test_to_one_upsert_create_new[session-tracked-async-aiosqlite_engine]
+  '''
+  INSERT INTO color (name, created_at, updated_at)
+  VALUES (?, ?, ?)
+      ON
+  CONFLICT (id) DO UPDATE
+     SET name = excluded.name RETURNING id
+  '''
+# ---
+# name: test_to_one_upsert_create_new[session-tracked-async-aiosqlite_engine].1
+  '''
+  UPDATE fruit
+     SET name = ?,
+         color_id = ?,
+         sweetness = ?,
+         water_percent = ?,
+         updated_at = ?
+   WHERE fruit.id = ?
+  '''
+# ---
+# name: test_to_one_upsert_create_new[session-tracked-async-aiosqlite_engine].2
+  '''
+  SELECT fruit__color.name,
+         fruit__color.id,
+         fruit.name AS name_1,
+         fruit.id AS id_1
+    FROM fruit AS fruit
+    LEFT OUTER JOIN color AS fruit__color
+      ON fruit__color.id = fruit.color_id
+   WHERE fruit.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY fruit.id ASC,
+            fruit__color.id ASC
+  '''
+# ---
+# name: test_to_one_upsert_create_new[session-tracked-async-asyncmy_engine]
+  '''
+  INSERT INTO color (name, created_at, updated_at)
+  VALUES (%s, %s, %s) AS NEW
+      ON DUPLICATE KEY UPDATE name = new.name,
+         id = last_insert_id(color.id)
+  '''
+# ---
+# name: test_to_one_upsert_create_new[session-tracked-async-asyncmy_engine].1
+  '''
+  UPDATE fruit
+     SET name = %s,
+         color_id = %s,
+         sweetness = %s,
+         water_percent = %s,
+         updated_at = %s
+   WHERE fruit.id = %s
+  '''
+# ---
+# name: test_to_one_upsert_create_new[session-tracked-async-asyncmy_engine].2
+  '''
+  SELECT fruit__color.name,
+         fruit__color.id,
+         fruit.name AS name_1,
+         fruit.id AS id_1
+    FROM fruit AS fruit
+    LEFT OUTER JOIN color AS fruit__color
+      ON fruit__color.id = fruit.color_id
+   WHERE fruit.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY fruit.id ASC,
+            fruit__color.id ASC
+  '''
+# ---
+# name: test_to_one_upsert_create_new[session-tracked-async-asyncpg_engine]
+  '''
+  INSERT INTO color (name, created_at, updated_at, id)
+  VALUES ($1::VARCHAR, $2::TIMESTAMP WITHOUT TIME ZONE, $3::TIMESTAMP WITHOUT TIME ZONE, nextval('color_id_seq'))
+      ON
+  CONFLICT (id) DO UPDATE
+     SET name = excluded.name RETURNING color.id
+  '''
+# ---
+# name: test_to_one_upsert_create_new[session-tracked-async-asyncpg_engine].1
+  '''
+  UPDATE fruit
+     SET name = $1::VARCHAR,
+         color_id = $2::INTEGER,
+         sweetness = $3::INTEGER,
+         water_percent = $4::FLOAT,
+         updated_at = $5::TIMESTAMP WITHOUT TIME
+    ZONE
+   WHERE fruit.id = $6::INTEGER
+  '''
+# ---
+# name: test_to_one_upsert_create_new[session-tracked-async-asyncpg_engine].2
+  '''
+  SELECT fruit__color.name,
+         fruit__color.id,
+         fruit.name AS name_1,
+         fruit.id AS id_1
+    FROM fruit AS fruit
+    LEFT OUTER JOIN color AS fruit__color
+      ON fruit__color.id = fruit.color_id
+   WHERE fruit.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY fruit.id ASC,
+            fruit__color.id ASC
+  '''
+# ---
+# name: test_to_one_upsert_create_new[session-tracked-async-psycopg_async_engine]
+  '''
+  INSERT INTO color (name, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('color_id_seq'))
+      ON
+  CONFLICT (id) DO UPDATE
+     SET name = excluded.name RETURNING color.id
+  '''
+# ---
+# name: test_to_one_upsert_create_new[session-tracked-async-psycopg_async_engine].1
+  '''
+  UPDATE fruit
+     SET name = %(name)s::VARCHAR,
+         color_id = %(color_id)s::INTEGER,
+         sweetness = %(sweetness)s::INTEGER,
+         water_percent = %(water_percent)s,
+         updated_at = %(updated_at)s::TIMESTAMP WITHOUT TIME
+    ZONE
+   WHERE fruit.id = %(fruit_id)s::INTEGER
+  '''
+# ---
+# name: test_to_one_upsert_create_new[session-tracked-async-psycopg_async_engine].2
+  '''
+  SELECT fruit__color.name,
+         fruit__color.id,
+         fruit.name AS name_1,
+         fruit.id AS id_1
+    FROM fruit AS fruit
+    LEFT OUTER JOIN color AS fruit__color
+      ON fruit__color.id = fruit.color_id
+   WHERE fruit.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY fruit.id ASC,
+            fruit__color.id ASC
+  '''
+# ---
+# name: test_to_one_upsert_create_new[session-tracked-sync-psycopg_engine]
+  '''
+  INSERT INTO color (name, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('color_id_seq'))
+      ON
+  CONFLICT (id) DO UPDATE
+     SET name = excluded.name RETURNING color.id
+  '''
+# ---
+# name: test_to_one_upsert_create_new[session-tracked-sync-psycopg_engine].1
+  '''
+  UPDATE fruit
+     SET name = %(name)s::VARCHAR,
+         color_id = %(color_id)s::INTEGER,
+         sweetness = %(sweetness)s::INTEGER,
+         water_percent = %(water_percent)s,
+         updated_at = %(updated_at)s::TIMESTAMP WITHOUT TIME
+    ZONE
+   WHERE fruit.id = %(fruit_id)s::INTEGER
+  '''
+# ---
+# name: test_to_one_upsert_create_new[session-tracked-sync-psycopg_engine].2
+  '''
+  SELECT fruit__color.name,
+         fruit__color.id,
+         fruit.name AS name_1,
+         fruit.id AS id_1
+    FROM fruit AS fruit
+    LEFT OUTER JOIN color AS fruit__color
+      ON fruit__color.id = fruit.color_id
+   WHERE fruit.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY fruit.id ASC,
+            fruit__color.id ASC
+  '''
+# ---
+# name: test_to_one_upsert_create_new[session-tracked-sync-sqlite_engine]
+  '''
+  INSERT INTO color (name, created_at, updated_at)
+  VALUES (?, ?, ?)
+      ON
+  CONFLICT (id) DO UPDATE
+     SET name = excluded.name RETURNING id
+  '''
+# ---
+# name: test_to_one_upsert_create_new[session-tracked-sync-sqlite_engine].1
+  '''
+  UPDATE fruit
+     SET name = ?,
+         color_id = ?,
+         sweetness = ?,
+         water_percent = ?,
+         updated_at = ?
+   WHERE fruit.id = ?
+  '''
+# ---
+# name: test_to_one_upsert_create_new[session-tracked-sync-sqlite_engine].2
+  '''
+  SELECT fruit__color.name,
+         fruit__color.id,
+         fruit.name AS name_1,
+         fruit.id AS id_1
+    FROM fruit AS fruit
+    LEFT OUTER JOIN color AS fruit__color
+      ON fruit__color.id = fruit.color_id
+   WHERE fruit.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY fruit.id ASC,
+            fruit__color.id ASC
+  '''
+# ---
+# name: test_to_one_upsert_update_existing[session-tracked-async-aiosqlite_engine]
+  '''
+  UPDATE fruit
+     SET name = ?,
+         color_id = ?,
+         updated_at = ?
+   WHERE fruit.id = ?
+  '''
+# ---
+# name: test_to_one_upsert_update_existing[session-tracked-async-aiosqlite_engine].1
+  '''
+  UPDATE fruit
+     SET name = ?,
+         color_id = ?,
+         updated_at = ?
+   WHERE fruit.id = ?
+  '''
+# ---
+# name: test_to_one_upsert_update_existing[session-tracked-async-aiosqlite_engine].2
+  '''
+  SELECT fruit__color.name,
+         fruit__color.id,
+         fruit.name AS name_1,
+         fruit.id AS id_1
+    FROM fruit AS fruit
+    LEFT OUTER JOIN color AS fruit__color
+      ON fruit__color.id = fruit.color_id
+   WHERE fruit.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY fruit.id ASC,
+            fruit__color.id ASC
+  '''
+# ---
+# name: test_to_one_upsert_update_existing[session-tracked-async-asyncmy_engine]
+  '''
+  UPDATE fruit
+     SET name = %s,
+         color_id = %s,
+         updated_at = %s
+   WHERE fruit.id = %s
+  '''
+# ---
+# name: test_to_one_upsert_update_existing[session-tracked-async-asyncmy_engine].1
+  '''
+  UPDATE fruit
+     SET name = %s,
+         color_id = %s,
+         updated_at = %s
+   WHERE fruit.id = %s
+  '''
+# ---
+# name: test_to_one_upsert_update_existing[session-tracked-async-asyncmy_engine].2
+  '''
+  SELECT fruit__color.name,
+         fruit__color.id,
+         fruit.name AS name_1,
+         fruit.id AS id_1
+    FROM fruit AS fruit
+    LEFT OUTER JOIN color AS fruit__color
+      ON fruit__color.id = fruit.color_id
+   WHERE fruit.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY fruit.id ASC,
+            fruit__color.id ASC
+  '''
+# ---
+# name: test_to_one_upsert_update_existing[session-tracked-async-asyncpg_engine]
+  '''
+  UPDATE fruit
+     SET name = $1::VARCHAR,
+         color_id = $2::INTEGER,
+         updated_at = $3::TIMESTAMP WITHOUT TIME
+    ZONE
+   WHERE fruit.id = $4::INTEGER
+  '''
+# ---
+# name: test_to_one_upsert_update_existing[session-tracked-async-asyncpg_engine].1
+  '''
+  UPDATE fruit
+     SET name = $1::VARCHAR,
+         color_id = $2::INTEGER,
+         updated_at = $3::TIMESTAMP WITHOUT TIME
+    ZONE
+   WHERE fruit.id = $4::INTEGER
+  '''
+# ---
+# name: test_to_one_upsert_update_existing[session-tracked-async-asyncpg_engine].2
+  '''
+  SELECT fruit__color.name,
+         fruit__color.id,
+         fruit.name AS name_1,
+         fruit.id AS id_1
+    FROM fruit AS fruit
+    LEFT OUTER JOIN color AS fruit__color
+      ON fruit__color.id = fruit.color_id
+   WHERE fruit.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY fruit.id ASC,
+            fruit__color.id ASC
+  '''
+# ---
+# name: test_to_one_upsert_update_existing[session-tracked-async-psycopg_async_engine]
+  '''
+  UPDATE fruit
+     SET name = %(name)s::VARCHAR,
+         color_id = %(color_id)s::INTEGER,
+         updated_at = %(updated_at)s::TIMESTAMP WITHOUT TIME
+    ZONE
+   WHERE fruit.id = %(fruit_id)s::INTEGER
+  '''
+# ---
+# name: test_to_one_upsert_update_existing[session-tracked-async-psycopg_async_engine].1
+  '''
+  UPDATE fruit
+     SET name = %(name)s::VARCHAR,
+         color_id = %(color_id)s::INTEGER,
+         updated_at = %(updated_at)s::TIMESTAMP WITHOUT TIME
+    ZONE
+   WHERE fruit.id = %(fruit_id)s::INTEGER
+  '''
+# ---
+# name: test_to_one_upsert_update_existing[session-tracked-async-psycopg_async_engine].2
+  '''
+  SELECT fruit__color.name,
+         fruit__color.id,
+         fruit.name AS name_1,
+         fruit.id AS id_1
+    FROM fruit AS fruit
+    LEFT OUTER JOIN color AS fruit__color
+      ON fruit__color.id = fruit.color_id
+   WHERE fruit.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY fruit.id ASC,
+            fruit__color.id ASC
+  '''
+# ---
+# name: test_to_one_upsert_update_existing[session-tracked-sync-psycopg_engine]
+  '''
+  UPDATE fruit
+     SET name = %(name)s::VARCHAR,
+         color_id = %(color_id)s::INTEGER,
+         updated_at = %(updated_at)s::TIMESTAMP WITHOUT TIME
+    ZONE
+   WHERE fruit.id = %(fruit_id)s::INTEGER
+  '''
+# ---
+# name: test_to_one_upsert_update_existing[session-tracked-sync-psycopg_engine].1
+  '''
+  UPDATE fruit
+     SET name = %(name)s::VARCHAR,
+         color_id = %(color_id)s::INTEGER,
+         updated_at = %(updated_at)s::TIMESTAMP WITHOUT TIME
+    ZONE
+   WHERE fruit.id = %(fruit_id)s::INTEGER
+  '''
+# ---
+# name: test_to_one_upsert_update_existing[session-tracked-sync-psycopg_engine].2
+  '''
+  SELECT fruit__color.name,
+         fruit__color.id,
+         fruit.name AS name_1,
+         fruit.id AS id_1
+    FROM fruit AS fruit
+    LEFT OUTER JOIN color AS fruit__color
+      ON fruit__color.id = fruit.color_id
+   WHERE fruit.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY fruit.id ASC,
+            fruit__color.id ASC
+  '''
+# ---
+# name: test_to_one_upsert_update_existing[session-tracked-sync-sqlite_engine]
+  '''
+  UPDATE fruit
+     SET name = ?,
+         color_id = ?,
+         updated_at = ?
+   WHERE fruit.id = ?
+  '''
+# ---
+# name: test_to_one_upsert_update_existing[session-tracked-sync-sqlite_engine].1
+  '''
+  UPDATE fruit
+     SET name = ?,
+         color_id = ?,
+         updated_at = ?
+   WHERE fruit.id = ?
+  '''
+# ---
+# name: test_to_one_upsert_update_existing[session-tracked-sync-sqlite_engine].2
+  '''
+  SELECT fruit__color.name,
+         fruit__color.id,
+         fruit.name AS name_1,
+         fruit.id AS id_1
+    FROM fruit AS fruit
+    LEFT OUTER JOIN color AS fruit__color
+      ON fruit__color.id = fruit.color_id
+   WHERE fruit.id IN (__[POSTCOMPILE_id_2])
+   ORDER BY fruit.id ASC,
+            fruit__color.id ASC
+  '''
+# ---

--- a/tests/integration/__snapshots__/test_upsert.ambr
+++ b/tests/integration/__snapshots__/test_upsert.ambr
@@ -1628,6 +1628,100 @@
    ORDER BY fruit.id ASC
   '''
 # ---
+# name: test_upsert_one_existing[session-tracked-async-pk-constraint-aiosqlite_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON
+  CONFLICT (id) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick,
+         id = excluded.id RETURNING id
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-async-pk-constraint-aiosqlite_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-async-pk-constraint-asyncmy_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%s, %s, %s, %s, %s, %s, %s) AS NEW
+      ON DUPLICATE KEY UPDATE name = new.name,
+         sweetness = new.sweetness,
+         water_percent = new.water_percent,
+         best_time_to_pick = new.best_time_to_pick,
+         id = new.id
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-async-pk-constraint-asyncmy_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-async-pk-constraint-asyncpg_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES ($1::VARCHAR, $2::INTEGER, $3::FLOAT, $4::TIME WITHOUT TIME ZONE, $5::TIMESTAMP WITHOUT TIME ZONE, $6::TIMESTAMP WITHOUT TIME ZONE, $7::INTEGER)
+      ON
+  CONFLICT (id) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick,
+         id = excluded.id
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-async-pk-constraint-asyncpg_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-async-pk-constraint-psycopg_async_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, %(id)s::INTEGER)
+      ON
+  CONFLICT (id) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick,
+         id = excluded.id
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-async-pk-constraint-psycopg_async_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
 # name: test_upsert_one_existing[session-tracked-async-psycopg_async_engine]
   '''
   INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
@@ -1641,6 +1735,145 @@
   '''
 # ---
 # name: test_upsert_one_existing[session-tracked-async-psycopg_async_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-async-unique-constraint-aiosqlite_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (?, ?, ?, ?, ?, ?)
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING id
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-async-unique-constraint-aiosqlite_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-async-unique-constraint-asyncmy_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (%s, %s, %s, %s, %s, %s) AS NEW
+      ON DUPLICATE KEY UPDATE name = new.name,
+         sweetness = new.sweetness,
+         water_percent = new.water_percent,
+         best_time_to_pick = new.best_time_to_pick,
+         id = last_insert_id(fruit.id)
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-async-unique-constraint-asyncmy_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-async-unique-constraint-asyncpg_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES ($1::VARCHAR, $2::INTEGER, $3::FLOAT, $4::TIME WITHOUT TIME ZONE, $5::TIMESTAMP WITHOUT TIME ZONE, $6::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-async-unique-constraint-asyncpg_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-async-unique-constraint-psycopg_async_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-async-unique-constraint-psycopg_async_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-sync-pk-constraint-psycopg_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, %(id)s::INTEGER)
+      ON
+  CONFLICT (id) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick,
+         id = excluded.id
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-sync-pk-constraint-psycopg_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-sync-pk-constraint-sqlite_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON
+  CONFLICT (id) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick,
+         id = excluded.id RETURNING id
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-sync-pk-constraint-sqlite_engine].1
   '''
   SELECT fruit.name,
          fruit.sweetness,
@@ -1687,6 +1920,52 @@
   '''
 # ---
 # name: test_upsert_one_existing[session-tracked-sync-sqlite_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-sync-unique-constraint-psycopg_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-sync-unique-constraint-psycopg_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-sync-unique-constraint-sqlite_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (?, ?, ?, ?, ?, ?)
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING id
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-sync-unique-constraint-sqlite_engine].1
   '''
   SELECT fruit.name,
          fruit.sweetness,

--- a/tests/integration/__snapshots__/test_upsert.ambr
+++ b/tests/integration/__snapshots__/test_upsert.ambr
@@ -1192,3 +1192,645 @@
             fruit__color.id ASC
   '''
 # ---
+# name: test_upsert_many_new[session-tracked-async-aiosqlite_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (?, ?, ?, ?, ?, ?)
+      ON
+  CONFLICT (id) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING id
+  '''
+# ---
+# name: test_upsert_many_new[session-tracked-async-aiosqlite_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_many_new[session-tracked-async-asyncmy_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (%s, %s, %s, %s, %s, %s) AS NEW
+      ON DUPLICATE KEY UPDATE name = new.name,
+         sweetness = new.sweetness,
+         water_percent = new.water_percent,
+         best_time_to_pick = new.best_time_to_pick,
+         id = last_insert_id(fruit.id)
+  '''
+# ---
+# name: test_upsert_many_new[session-tracked-async-asyncmy_engine].1
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (%s, %s, %s, %s, %s, %s) AS NEW
+      ON DUPLICATE KEY UPDATE name = new.name,
+         sweetness = new.sweetness,
+         water_percent = new.water_percent,
+         best_time_to_pick = new.best_time_to_pick,
+         id = last_insert_id(fruit.id)
+  '''
+# ---
+# name: test_upsert_many_new[session-tracked-async-asyncmy_engine].2
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_many_new[session-tracked-async-asyncpg_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES ($1::VARCHAR, $2::INTEGER, $3::FLOAT, $4::TIME WITHOUT TIME ZONE, $5::TIMESTAMP WITHOUT TIME ZONE, $6::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (id) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_upsert_many_new[session-tracked-async-asyncpg_engine].1
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES ($1::VARCHAR, $2::INTEGER, $3::FLOAT, $4::TIME WITHOUT TIME ZONE, $5::TIMESTAMP WITHOUT TIME ZONE, $6::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (id) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_upsert_many_new[session-tracked-async-asyncpg_engine].2
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_many_new[session-tracked-async-psycopg_async_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (id) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_upsert_many_new[session-tracked-async-psycopg_async_engine].1
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (id) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_upsert_many_new[session-tracked-async-psycopg_async_engine].2
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_many_new[session-tracked-sync-psycopg_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (id) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_upsert_many_new[session-tracked-sync-psycopg_engine].1
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (id) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_upsert_many_new[session-tracked-sync-psycopg_engine].2
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_many_new[session-tracked-sync-sqlite_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (?, ?, ?, ?, ?, ?)
+      ON
+  CONFLICT (id) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING id
+  '''
+# ---
+# name: test_upsert_many_new[session-tracked-sync-sqlite_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_many_new_and_existing[session-tracked-async-aiosqlite_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (?, ?, ?, ?, ?, ?)
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING id
+  '''
+# ---
+# name: test_upsert_many_new_and_existing[session-tracked-async-aiosqlite_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_many_new_and_existing[session-tracked-async-asyncmy_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (%s, %s, %s, %s, %s, %s) AS NEW
+      ON DUPLICATE KEY UPDATE name = new.name,
+         sweetness = new.sweetness,
+         water_percent = new.water_percent,
+         best_time_to_pick = new.best_time_to_pick,
+         id = last_insert_id(fruit.id)
+  '''
+# ---
+# name: test_upsert_many_new_and_existing[session-tracked-async-asyncmy_engine].1
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (%s, %s, %s, %s, %s, %s) AS NEW
+      ON DUPLICATE KEY UPDATE name = new.name,
+         sweetness = new.sweetness,
+         water_percent = new.water_percent,
+         best_time_to_pick = new.best_time_to_pick,
+         id = last_insert_id(fruit.id)
+  '''
+# ---
+# name: test_upsert_many_new_and_existing[session-tracked-async-asyncmy_engine].2
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_many_new_and_existing[session-tracked-async-asyncpg_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES ($1::VARCHAR, $2::INTEGER, $3::FLOAT, $4::TIME WITHOUT TIME ZONE, $5::TIMESTAMP WITHOUT TIME ZONE, $6::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_upsert_many_new_and_existing[session-tracked-async-asyncpg_engine].1
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES ($1::VARCHAR, $2::INTEGER, $3::FLOAT, $4::TIME WITHOUT TIME ZONE, $5::TIMESTAMP WITHOUT TIME ZONE, $6::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_upsert_many_new_and_existing[session-tracked-async-asyncpg_engine].2
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_many_new_and_existing[session-tracked-async-psycopg_async_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_upsert_many_new_and_existing[session-tracked-async-psycopg_async_engine].1
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_upsert_many_new_and_existing[session-tracked-async-psycopg_async_engine].2
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_many_new_and_existing[session-tracked-sync-psycopg_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_upsert_many_new_and_existing[session-tracked-sync-psycopg_engine].1
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_upsert_many_new_and_existing[session-tracked-sync-psycopg_engine].2
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_many_new_and_existing[session-tracked-sync-sqlite_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (?, ?, ?, ?, ?, ?)
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING id
+  '''
+# ---
+# name: test_upsert_many_new_and_existing[session-tracked-sync-sqlite_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-async-aiosqlite_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (?, ?, ?, ?, ?, ?)
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING id
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-async-aiosqlite_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-async-asyncmy_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (%s, %s, %s, %s, %s, %s) AS NEW
+      ON DUPLICATE KEY UPDATE name = new.name,
+         sweetness = new.sweetness,
+         water_percent = new.water_percent,
+         best_time_to_pick = new.best_time_to_pick,
+         id = last_insert_id(fruit.id)
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-async-asyncmy_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-async-asyncpg_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES ($1::VARCHAR, $2::INTEGER, $3::FLOAT, $4::TIME WITHOUT TIME ZONE, $5::TIMESTAMP WITHOUT TIME ZONE, $6::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-async-asyncpg_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-async-psycopg_async_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-async-psycopg_async_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-sync-psycopg_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-sync-psycopg_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-sync-sqlite_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (?, ?, ?, ?, ?, ?)
+      ON
+  CONFLICT (name) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING id
+  '''
+# ---
+# name: test_upsert_one_existing[session-tracked-sync-sqlite_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_one_new[session-tracked-async-aiosqlite_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (?, ?, ?, ?, ?, ?)
+      ON
+  CONFLICT (id) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING id
+  '''
+# ---
+# name: test_upsert_one_new[session-tracked-async-aiosqlite_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_one_new[session-tracked-async-asyncmy_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (%s, %s, %s, %s, %s, %s) AS NEW
+      ON DUPLICATE KEY UPDATE name = new.name,
+         sweetness = new.sweetness,
+         water_percent = new.water_percent,
+         best_time_to_pick = new.best_time_to_pick,
+         id = last_insert_id(fruit.id)
+  '''
+# ---
+# name: test_upsert_one_new[session-tracked-async-asyncmy_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_one_new[session-tracked-async-asyncpg_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES ($1::VARCHAR, $2::INTEGER, $3::FLOAT, $4::TIME WITHOUT TIME ZONE, $5::TIMESTAMP WITHOUT TIME ZONE, $6::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (id) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_upsert_one_new[session-tracked-async-asyncpg_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_one_new[session-tracked-async-psycopg_async_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (id) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_upsert_one_new[session-tracked-async-psycopg_async_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_one_new[session-tracked-sync-psycopg_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at, id)
+  VALUES (%(name)s::VARCHAR, %(sweetness)s::INTEGER, %(water_percent)s, %(best_time_to_pick)s::TIME WITHOUT TIME ZONE, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE, %(updated_at)s::TIMESTAMP WITHOUT TIME ZONE, nextval('fruit_id_seq'))
+      ON
+  CONFLICT (id) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING fruit.id
+  '''
+# ---
+# name: test_upsert_one_new[session-tracked-sync-psycopg_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---
+# name: test_upsert_one_new[session-tracked-sync-sqlite_engine]
+  '''
+  INSERT INTO fruit (name, sweetness, water_percent, best_time_to_pick, created_at, updated_at)
+  VALUES (?, ?, ?, ?, ?, ?)
+      ON
+  CONFLICT (id) DO UPDATE
+     SET name = excluded.name,
+         sweetness = excluded.sweetness,
+         water_percent = excluded.water_percent,
+         best_time_to_pick = excluded.best_time_to_pick RETURNING id
+  '''
+# ---
+# name: test_upsert_one_new[session-tracked-sync-sqlite_engine].1
+  '''
+  SELECT fruit.name,
+         fruit.sweetness,
+         fruit.water_percent,
+         fruit.id
+    FROM fruit AS fruit
+   WHERE fruit.id IN (__[POSTCOMPILE_id_1])
+   ORDER BY fruit.id ASC
+  '''
+# ---

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -834,7 +834,13 @@ class QueryTracker:
 
     @property
     def query_count(self) -> int:
-        return len(self.executions)
+        return len(
+            [
+                execution
+                for execution in self.executions
+                if isinstance(execution.clause_element, tuple(self._clause_map.values()))
+            ]
+        )
 
     def __getitem__(self, index: int) -> QueryInspector:
         return self.executions[index]

--- a/tests/integration/models.py
+++ b/tests/integration/models.py
@@ -10,6 +10,7 @@ from strawchemy.dto.utils import PRIVATE, READ_ONLY
 from sqlalchemy import (
     ARRAY,
     JSON,
+    VARCHAR,
     Date,
     DateTime,
     Double,
@@ -20,6 +21,7 @@ from sqlalchemy import (
     Sequence,
     Text,
     Time,
+    UniqueConstraint,
 )
 from sqlalchemy.dialects import mysql, postgresql, sqlite
 from sqlalchemy.ext.declarative import declared_attr
@@ -123,7 +125,7 @@ class DerivedProduct(Base):
 class Fruit(Base):
     __tablename__ = "fruit"
 
-    name: Mapped[str] = mapped_column(Text)
+    name: Mapped[str] = mapped_column(VARCHAR(255))
     color_id: Mapped[int | None] = mapped_column(ForeignKey("color.id"), nullable=True, default=None)
     color: Mapped[Color | None] = relationship("Color", back_populates="fruits")
     farms: Mapped[list[FruitFarm]] = relationship(FruitFarm)
@@ -135,6 +137,8 @@ class Fruit(Base):
     water_percent: Mapped[float] = mapped_column(Double)
     best_time_to_pick: Mapped[time] = mapped_column(TimeType, default=time(hour=9))
 
+    __table_args__ = (UniqueConstraint(name),)
+
     @hybrid_property
     def description(self) -> str:
         return f"The {self.name} color id is {self.color_id}"
@@ -144,7 +148,9 @@ class Color(Base):
     __tablename__ = "color"
 
     fruits: Mapped[list[Fruit]] = relationship("Fruit", back_populates="color")
-    name: Mapped[str] = mapped_column(Text)
+    name: Mapped[str] = mapped_column(VARCHAR(255))
+
+    __table_args__ = (UniqueConstraint(name),)
 
 
 class Group(Base):

--- a/tests/integration/test_distinct_on.py
+++ b/tests/integration/test_distinct_on.py
@@ -16,13 +16,13 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-def raw_colors() -> RawRecordData:
+def raw_users() -> RawRecordData:
     return [
-        {"id": 1, "name": "Red"},
-        {"id": 2, "name": "Red"},
-        {"id": 3, "name": "Orange"},
-        {"id": 4, "name": "Orange"},
-        {"id": 5, "name": "Pink"},
+        {"id": 1, "name": "Alice", "group_id": None, "bio": None},
+        {"id": 2, "name": "Alice", "group_id": None, "bio": None},
+        {"id": 3, "name": "Charlie", "group_id": None, "bio": None},
+        {"id": 4, "name": "Charlie", "group_id": None, "bio": None},
+        {"id": 4, "name": "Bob", "group_id": None, "bio": None},
     ]
 
 
@@ -39,12 +39,12 @@ async def test_distinct_on(
     deterministic_ordering: bool,
 ) -> None:
     config.deterministic_ordering = deterministic_ordering
-    result = await maybe_async(any_query("{ colors(distinctOn: [name]) { id name } }"))
+    result = await maybe_async(any_query("{ users(distinctOn: [name]) { id name } }"))
     assert not result.errors
     assert result.data
 
     expected = [{"id": 1, "name": "Red"}, {"id": 3, "name": "Orange"}, {"id": 5, "name": "Pink"}]
-    assert all(color in result.data["colors"] for color in expected)
+    assert all(user in result.data["users"] for user in expected)
 
     assert query_tracker.query_count == 1
     assert query_tracker[0].statement_formatted == sql_snapshot
@@ -55,13 +55,13 @@ async def test_distinct_and_order_by(
     any_query: AnyQueryExecutor, query_tracker: QueryTracker, sql_snapshot: SnapshotAssertion
 ) -> None:
     result = await maybe_async(
-        any_query("{ colors(distinctOn: [name], orderBy: [{name: ASC}, {id: DESC}]) { id name } }")
+        any_query("{ users(distinctOn: [name], orderBy: [{name: ASC}, {id: DESC}]) { id name } }")
     )
     assert not result.errors
     assert result.data
 
     expected = [{"id": 2, "name": "Red"}, {"id": 4, "name": "Orange"}, {"id": 5, "name": "Pink"}]
-    assert all(color in result.data["colors"] for color in expected)
+    assert all(user in result.data["users"] for user in expected)
 
     assert query_tracker.query_count == 1
     assert query_tracker[0].statement_formatted == sql_snapshot

--- a/tests/integration/test_distinct_on.py
+++ b/tests/integration/test_distinct_on.py
@@ -22,7 +22,7 @@ def raw_users() -> RawRecordData:
         {"id": 2, "name": "Alice", "group_id": None, "bio": None},
         {"id": 3, "name": "Charlie", "group_id": None, "bio": None},
         {"id": 4, "name": "Charlie", "group_id": None, "bio": None},
-        {"id": 4, "name": "Bob", "group_id": None, "bio": None},
+        {"id": 5, "name": "Bob", "group_id": None, "bio": None},
     ]
 
 
@@ -43,7 +43,8 @@ async def test_distinct_on(
     assert not result.errors
     assert result.data
 
-    expected = [{"id": 1, "name": "Red"}, {"id": 3, "name": "Orange"}, {"id": 5, "name": "Pink"}]
+    expected = [{"id": 1, "name": "Alice"}, {"id": 3, "name": "Charlie"}, {"id": 5, "name": "Bob"}]
+    assert len(result.data["users"]) == len(expected)
     assert all(user in result.data["users"] for user in expected)
 
     assert query_tracker.query_count == 1
@@ -60,8 +61,7 @@ async def test_distinct_and_order_by(
     assert not result.errors
     assert result.data
 
-    expected = [{"id": 2, "name": "Red"}, {"id": 4, "name": "Orange"}, {"id": 5, "name": "Pink"}]
-    assert all(user in result.data["users"] for user in expected)
+    assert result.data["users"] == [{"id": 2, "name": "Alice"}, {"id": 5, "name": "Bob"}, {"id": 4, "name": "Charlie"}]
 
     assert query_tracker.query_count == 1
     assert query_tracker[0].statement_formatted == sql_snapshot

--- a/tests/integration/test_multiple_queries.py
+++ b/tests/integration/test_multiple_queries.py
@@ -13,7 +13,7 @@ async def test_create_update_delete(any_query: AnyQueryExecutor) -> None:
 
     create_query = """
         mutation {{
-            createColor(data: {{ id: {id}, name: "Blue" }}) {{
+            createColor(data: {{ id: {id}, name: "New Blue" }}) {{
                 name
             }}
         }}
@@ -24,7 +24,7 @@ async def test_create_update_delete(any_query: AnyQueryExecutor) -> None:
             updateColor(
                 data: {{
                     id: {id},
-                    name: "Green"
+                    name: "New Green"
                 }}
             ) {{
                 id
@@ -67,27 +67,27 @@ async def test_create_update_delete(any_query: AnyQueryExecutor) -> None:
     result = await maybe_async(any_query(create_query.format(id=color_id)))
     assert not result.errors
     assert result.data
-    assert result.data["createColor"] == {"name": "Blue"}
+    assert result.data["createColor"] == {"name": "New Blue"}
     # Get
     result = await maybe_async(any_query(get_query.format(id=color_id)))
     assert not result.errors
     assert result.data
-    assert result.data["color"] == {"name": "Blue"}
+    assert result.data["color"] == {"name": "New Blue"}
     # Update
     result = await maybe_async(any_query(update_query.format(id=color_id)))
     assert not result.errors
     assert result.data
-    assert result.data["updateColor"] == {"name": "Green", "id": color_id}
+    assert result.data["updateColor"] == {"name": "New Green", "id": color_id}
     # Get
     result = await maybe_async(any_query(get_query.format(id=color_id)))
     assert not result.errors
     assert result.data
-    assert result.data["color"] == {"name": "Green"}
+    assert result.data["color"] == {"name": "New Green"}
     # Delete
     result = await maybe_async(any_query(delete_query.format(id=color_id)))
     assert not result.errors
     assert result.data
-    assert result.data["deleteColor"] == [{"name": "Green", "id": color_id}]
+    assert result.data["deleteColor"] == [{"name": "New Green", "id": color_id}]
     # List
     result = await maybe_async(any_query(list_query.format(id=color_id)))
     assert not result.errors

--- a/tests/integration/test_upsert.py
+++ b/tests/integration/test_upsert.py
@@ -20,6 +20,14 @@ pytestmark = [pytest.mark.integration]
 async def test_upsert_one_new(
     any_query: AnyQueryExecutor, query_tracker: QueryTracker, sql_snapshot: SnapshotAssertion
 ) -> None:
+    """Test upserting a single new fruit record.
+
+    This test verifies that the upsertFruit mutation correctly creates a new fruit
+    record when no existing record matches. The test expects:
+    - A successful GraphQL mutation response
+    - The new fruit data to be returned correctly
+    - Exactly 2 SQL queries: 1 INSERT and 1 SELECT
+    """
     query = """
         mutation {
             upsertFruit(
@@ -53,6 +61,16 @@ async def test_upsert_one_new(
 async def test_upsert_one_existing(
     any_query: AnyQueryExecutor, query_tracker: QueryTracker, sql_snapshot: SnapshotAssertion
 ) -> None:
+    """Test upserting a single existing fruit record with conflict resolution.
+
+    This test verifies that the upsertFruit mutation correctly updates an existing
+    fruit record when a conflict is detected on the specified conflict field (name).
+    The test expects:
+    - A successful GraphQL mutation response with conflictFields specified
+    - The existing fruit record to be updated with new values
+    - The original ID to be preserved in the response
+    - Exactly 2 SQL queries: 1 INSERT (with conflict resolution) and 1 SELECT
+    """
     query = """
         mutation {
             upsertFruit(
@@ -89,6 +107,16 @@ async def test_upsert_one_existing(
 async def test_upsert_many_new(
     any_query: AnyQueryExecutor, query_tracker: QueryTracker, sql_snapshot: SnapshotAssertion, dialect: SupportedDialect
 ) -> None:
+    """Test upserting multiple new fruit records.
+
+    This test verifies that the upsertFruits mutation correctly creates multiple new
+    fruit records when no existing records match. The test expects:
+    - A successful GraphQL mutation response
+    - All new fruit data to be returned in the correct order
+    - Different SQL query patterns based on database dialect:
+      * PostgreSQL/MySQL: 3 queries (2 INSERTs + 1 SELECT)
+      * SQLite: 2 queries (1 batch INSERT + 1 SELECT)
+    """
     query = """
         mutation {
             upsertFruits(
@@ -132,6 +160,18 @@ async def test_upsert_many_new(
 async def test_upsert_many_new_and_existing(
     any_query: AnyQueryExecutor, query_tracker: QueryTracker, sql_snapshot: SnapshotAssertion, dialect: SupportedDialect
 ) -> None:
+    """Test upserting multiple fruits with mixed new and existing records.
+
+    This test verifies that the upsertFruits mutation correctly handles a batch
+    operation containing both new records (to be created) and existing records
+    (to be updated) based on conflict resolution using the name field. The test expects:
+    - A successful GraphQL mutation response with conflictFields specified
+    - Mixed create/update operations to be handled correctly
+    - All fruit data to be returned with updated values
+    - Different SQL query patterns based on database dialect:
+      * PostgreSQL/MySQL: 3 queries (2 INSERTs with conflict resolution + 1 SELECT)
+      * SQLite: 2 queries (1 batch INSERT with conflict resolution + 1 SELECT)
+    """
     query = """
         mutation {
             upsertFruits(

--- a/tests/integration/types/mysql.py
+++ b/tests/integration/types/mysql.py
@@ -98,6 +98,10 @@ class UserCreate: ...
 class UserUpdateInput: ...
 
 
+@strawchemy.distinct_on(User, include="all")
+class UserDistinctOn: ...
+
+
 # Fruit
 
 
@@ -342,7 +346,10 @@ class AsyncQuery:
     # User
     user: UserType = strawchemy.field(repository_type=StrawchemyAsyncRepository)
     users: list[UserType] = strawchemy.field(
-        filter_input=UserFilter, order_by=UserOrderBy, repository_type=StrawchemyAsyncRepository
+        filter_input=UserFilter,
+        order_by=UserOrderBy,
+        repository_type=StrawchemyAsyncRepository,
+        distinct_on=UserDistinctOn,
     )
 
     # Custom resolvers
@@ -424,7 +431,10 @@ class SyncQuery:
     # User
     user: UserType = strawchemy.field(repository_type=StrawchemySyncRepository)
     users: list[UserType] = strawchemy.field(
-        filter_input=UserFilter, order_by=UserOrderBy, repository_type=StrawchemySyncRepository
+        filter_input=UserFilter,
+        order_by=UserOrderBy,
+        repository_type=StrawchemySyncRepository,
+        distinct_on=UserDistinctOn,
     )
 
     # Custom resolvers

--- a/tests/integration/types/mysql.py
+++ b/tests/integration/types/mysql.py
@@ -164,6 +164,14 @@ class FruitCreateInput: ...
 class FruitUpdateInput: ...
 
 
+@strawchemy.upsert_update_fields(Fruit, include="all")
+class FruitUpsertFields: ...
+
+
+@strawchemy.upsert_conflict_fields(Fruit, include="all")
+class FruitUpsertConflictFields: ...
+
+
 # Color
 
 
@@ -524,6 +532,19 @@ class AsyncMutation:
     update_fruits: list[FruitType] = strawchemy.update_by_ids(
         FruitUpdateInput, repository_type=StrawchemyAsyncRepository
     )
+    # Fruit - upsert
+    upsert_fruit: FruitType = strawchemy.upsert(
+        FruitCreateInput,
+        update_fields=FruitUpsertFields,
+        conflict_fields=FruitUpsertConflictFields,
+        repository_type=StrawchemyAsyncRepository,
+    )
+    upsert_fruits: list[FruitType] = strawchemy.upsert(
+        FruitCreateInput,
+        update_fields=FruitUpsertFields,
+        conflict_fields=FruitUpsertConflictFields,
+        repository_type=StrawchemyAsyncRepository,
+    )
     # User - Update
     update_user: UserType = strawchemy.update_by_ids(UserUpdateInput, repository_type=StrawchemyAsyncRepository)
     create_user: UserType = strawchemy.create(UserCreate, repository_type=StrawchemyAsyncRepository)
@@ -635,6 +656,19 @@ class SyncMutation:
     update_fruit: FruitType = strawchemy.update_by_ids(FruitUpdateInput, repository_type=StrawchemySyncRepository)
     update_fruits: list[FruitType] = strawchemy.update_by_ids(
         FruitUpdateInput, repository_type=StrawchemySyncRepository
+    )
+    # Fruit - upsert
+    upsert_fruit: FruitType = strawchemy.upsert(
+        FruitCreateInput,
+        update_fields=FruitUpsertFields,
+        conflict_fields=FruitUpsertConflictFields,
+        repository_type=StrawchemySyncRepository,
+    )
+    upsert_fruits: list[FruitType] = strawchemy.upsert(
+        FruitCreateInput,
+        update_fields=FruitUpsertFields,
+        conflict_fields=FruitUpsertConflictFields,
+        repository_type=StrawchemySyncRepository,
     )
     # User - Update
     update_user: UserType = strawchemy.update_by_ids(UserUpdateInput, repository_type=StrawchemySyncRepository)

--- a/tests/integration/types/mysql.py
+++ b/tests/integration/types/mysql.py
@@ -23,16 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.util import AliasedClass
 from strawberry.extensions.field_extension import AsyncExtensionResolver, FieldExtension, SyncExtensionResolver
-from tests.integration.models import (
-    Color,
-    DateTimeModel,
-    Fruit,
-    FruitFarm,
-    IntervalModel,
-    JSONModel,
-    RankedUser,
-    User,
-)
+from tests.integration.models import Color, DateTimeModel, Fruit, FruitFarm, IntervalModel, JSONModel, RankedUser, User
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -532,15 +523,15 @@ class AsyncMutation:
 
     @strawberry.field
     async def create_blue_color(self, info: strawberry.Info, data: ColorCreateInput) -> ColorType:
-        return (await StrawchemyAsyncRepository(ColorType, info).create(Input(data, name="Blue"))).graphql_type()
+        return (await StrawchemyAsyncRepository(ColorType, info).create(Input(data, name="New Blue"))).graphql_type()
 
     @strawberry.field
     async def create_apple_color(self, info: strawberry.Info, data: ColorCreateInput) -> ColorType:
         color_input = Input(data)
         color_input.instances[0].fruits.extend(
             [
-                Fruit(name="Apple", sweetness=1, water_percent=0.5),
-                Fruit(name="Strawberry", sweetness=1, water_percent=0.5),
+                Fruit(name="New Apple", sweetness=1, water_percent=0.5),
+                Fruit(name="New Strawberry", sweetness=1, water_percent=0.5),
             ]
         )
         return (await StrawchemyAsyncRepository(ColorType, info).create(color_input)).graphql_type()
@@ -550,8 +541,8 @@ class AsyncMutation:
         color_input = Input(data)
         session = cast("AsyncSession", info.context.session)
         apple, strawberry = (
-            Fruit(name="Apple", sweetness=1, water_percent=0.5),
-            Fruit(name="Strawberry", sweetness=1, water_percent=0.5),
+            Fruit(name="New Apple", sweetness=1, water_percent=0.5),
+            Fruit(name="New Strawberry", sweetness=1, water_percent=0.5),
         )
         session.add_all([apple, strawberry])
         await session.commit()
@@ -562,14 +553,14 @@ class AsyncMutation:
     @strawberry.field
     async def create_red_fruit(self, info: strawberry.Info, data: FruitCreateInput) -> FruitType:
         fruit_input = Input(data)
-        fruit_input.instances[0].color = Color(name="Red")
+        fruit_input.instances[0].color = Color(name="New Red")
         return (await StrawchemyAsyncRepository(FruitType, info).create(fruit_input)).graphql_type()
 
     @strawberry.field
     async def create_fruit_for_existing_color(self, info: strawberry.Info, data: FruitCreateInput) -> FruitType:
         fruit_input = Input(data)
         session = cast("AsyncSession", info.context.session)
-        red = Color(name="Red")
+        red = Color(name="New Red")
         session.add(red)
         await session.commit()
         fruit_input.instances[0].color = red
@@ -644,15 +635,15 @@ class SyncMutation:
 
     @strawberry.field
     def create_blue_color(self, info: strawberry.Info, data: ColorCreateInput) -> ColorType:
-        return StrawchemySyncRepository(ColorType, info).create(Input(data, name="Blue")).graphql_type()
+        return StrawchemySyncRepository(ColorType, info).create(Input(data, name="New Blue")).graphql_type()
 
     @strawberry.field
     def create_apple_color(self, info: strawberry.Info, data: ColorCreateInput) -> ColorType:
         color_input = Input(data)
         color_input.instances[0].fruits.extend(
             [
-                Fruit(name="Apple", sweetness=1, water_percent=0.5),
-                Fruit(name="Strawberry", sweetness=1, water_percent=0.5),
+                Fruit(name="New Apple", sweetness=1, water_percent=0.5),
+                Fruit(name="New Strawberry", sweetness=1, water_percent=0.5),
             ]
         )
         return StrawchemySyncRepository(ColorType, info).create(color_input).graphql_type()
@@ -662,8 +653,8 @@ class SyncMutation:
         color_input = Input(data)
         session = cast("Session", info.context.session)
         apple, strawberry = (
-            Fruit(name="Apple", sweetness=1, water_percent=0.5),
-            Fruit(name="Strawberry", sweetness=1, water_percent=0.5),
+            Fruit(name="New Apple", sweetness=1, water_percent=0.5),
+            Fruit(name="New Strawberry", sweetness=1, water_percent=0.5),
         )
         session.add_all([apple, strawberry])
         session.commit()
@@ -674,14 +665,14 @@ class SyncMutation:
     @strawberry.field
     def create_red_fruit(self, info: strawberry.Info, data: FruitCreateInput) -> FruitType:
         fruit_input = Input(data)
-        fruit_input.instances[0].color = Color(name="Red")
+        fruit_input.instances[0].color = Color(name="New Red")
         return StrawchemySyncRepository(FruitType, info).create(fruit_input).graphql_type()
 
     @strawberry.field
     def create_fruit_for_existing_color(self, info: strawberry.Info, data: FruitCreateInput) -> FruitType:
         fruit_input = Input(data)
         session = cast("Session", info.context.session)
-        red = Color(name="Red")
+        red = Color(name="New Red")
         session.add(red)
         session.commit()
         fruit_input.instances[0].color = red

--- a/tests/integration/types/postgres.py
+++ b/tests/integration/types/postgres.py
@@ -107,6 +107,10 @@ class UserCreate: ...
 class UserUpdateInput: ...
 
 
+@strawchemy.distinct_on(User, include="all")
+class UserDistinctOn: ...
+
+
 # Fruit
 
 
@@ -362,7 +366,10 @@ class AsyncQuery:
     # User
     user: UserType = strawchemy.field(repository_type=StrawchemyAsyncRepository)
     users: list[UserType] = strawchemy.field(
-        filter_input=UserFilter, order_by=UserOrderBy, repository_type=StrawchemyAsyncRepository
+        filter_input=UserFilter,
+        order_by=UserOrderBy,
+        repository_type=StrawchemyAsyncRepository,
+        distinct_on=UserDistinctOn,
     )
 
     # Custom resolvers
@@ -444,7 +451,10 @@ class SyncQuery:
     # User
     user: UserType = strawchemy.field(repository_type=StrawchemySyncRepository)
     users: list[UserType] = strawchemy.field(
-        filter_input=UserFilter, order_by=UserOrderBy, repository_type=StrawchemySyncRepository
+        filter_input=UserFilter,
+        order_by=UserOrderBy,
+        repository_type=StrawchemySyncRepository,
+        distinct_on=UserDistinctOn,
     )
 
     # Custom resolvers

--- a/tests/integration/types/postgres.py
+++ b/tests/integration/types/postgres.py
@@ -173,6 +173,14 @@ class FruitCreateInput: ...
 class FruitUpdateInput: ...
 
 
+@strawchemy.upsert_update_fields(Fruit, include="all")
+class FruitUpsertFields: ...
+
+
+@strawchemy.upsert_conflict_fields(Fruit, include="all")
+class FruitUpsertConflictFields: ...
+
+
 # Color
 
 
@@ -554,6 +562,19 @@ class AsyncMutation:
     update_fruits: list[FruitType] = strawchemy.update_by_ids(
         FruitUpdateInput, repository_type=StrawchemyAsyncRepository
     )
+    # Fruit - upsert
+    upsert_fruit: FruitType = strawchemy.upsert(
+        FruitCreateInput,
+        update_fields=FruitUpsertFields,
+        conflict_fields=FruitUpsertConflictFields,
+        repository_type=StrawchemyAsyncRepository,
+    )
+    upsert_fruits: list[FruitType] = strawchemy.upsert(
+        FruitCreateInput,
+        update_fields=FruitUpsertFields,
+        conflict_fields=FruitUpsertConflictFields,
+        repository_type=StrawchemyAsyncRepository,
+    )
     # User - Update
     update_user: UserType = strawchemy.update_by_ids(UserUpdateInput, repository_type=StrawchemyAsyncRepository)
     create_user: UserType = strawchemy.create(UserCreate, repository_type=StrawchemyAsyncRepository)
@@ -665,6 +686,19 @@ class SyncMutation:
     update_fruit: FruitType = strawchemy.update_by_ids(FruitUpdateInput, repository_type=StrawchemySyncRepository)
     update_fruits: list[FruitType] = strawchemy.update_by_ids(
         FruitUpdateInput, repository_type=StrawchemySyncRepository
+    )
+    # Fruit - upsert
+    upsert_fruit: FruitType = strawchemy.upsert(
+        FruitCreateInput,
+        update_fields=FruitUpsertFields,
+        conflict_fields=FruitUpsertConflictFields,
+        repository_type=StrawchemySyncRepository,
+    )
+    upsert_fruits: list[FruitType] = strawchemy.upsert(
+        FruitCreateInput,
+        update_fields=FruitUpsertFields,
+        conflict_fields=FruitUpsertConflictFields,
+        repository_type=StrawchemySyncRepository,
     )
     # User - Update
     update_user: UserType = strawchemy.update_by_ids(UserUpdateInput, repository_type=StrawchemySyncRepository)

--- a/tests/integration/types/postgres.py
+++ b/tests/integration/types/postgres.py
@@ -553,15 +553,15 @@ class AsyncMutation:
 
     @strawberry.field
     async def create_blue_color(self, info: strawberry.Info, data: ColorCreateInput) -> ColorType:
-        return (await StrawchemyAsyncRepository(ColorType, info).create(Input(data, name="Blue"))).graphql_type()
+        return (await StrawchemyAsyncRepository(ColorType, info).create(Input(data, name="New Blue"))).graphql_type()
 
     @strawberry.field
     async def create_apple_color(self, info: strawberry.Info, data: ColorCreateInput) -> ColorType:
         color_input = Input(data)
         color_input.instances[0].fruits.extend(
             [
-                Fruit(name="Apple", sweetness=1, water_percent=0.5),
-                Fruit(name="Strawberry", sweetness=1, water_percent=0.5),
+                Fruit(name="New Apple", sweetness=1, water_percent=0.5),
+                Fruit(name="New Strawberry", sweetness=1, water_percent=0.5),
             ]
         )
         return (await StrawchemyAsyncRepository(ColorType, info).create(color_input)).graphql_type()
@@ -571,8 +571,8 @@ class AsyncMutation:
         color_input = Input(data)
         session = cast("AsyncSession", info.context.session)
         apple, strawberry = (
-            Fruit(name="Apple", sweetness=1, water_percent=0.5),
-            Fruit(name="Strawberry", sweetness=1, water_percent=0.5),
+            Fruit(name="New Apple", sweetness=1, water_percent=0.5),
+            Fruit(name="New Strawberry", sweetness=1, water_percent=0.5),
         )
         session.add_all([apple, strawberry])
         await session.commit()
@@ -583,14 +583,14 @@ class AsyncMutation:
     @strawberry.field
     async def create_red_fruit(self, info: strawberry.Info, data: FruitCreateInput) -> FruitType:
         fruit_input = Input(data)
-        fruit_input.instances[0].color = Color(name="Red")
+        fruit_input.instances[0].color = Color(name="New Red")
         return (await StrawchemyAsyncRepository(FruitType, info).create(fruit_input)).graphql_type()
 
     @strawberry.field
     async def create_fruit_for_existing_color(self, info: strawberry.Info, data: FruitCreateInput) -> FruitType:
         fruit_input = Input(data)
         session = cast("AsyncSession", info.context.session)
-        red = Color(name="Red")
+        red = Color(name="New Red")
         session.add(red)
         await session.commit()
         fruit_input.instances[0].color = red
@@ -665,15 +665,15 @@ class SyncMutation:
 
     @strawberry.field
     def create_blue_color(self, info: strawberry.Info, data: ColorCreateInput) -> ColorType:
-        return StrawchemySyncRepository(ColorType, info).create(Input(data, name="Blue")).graphql_type()
+        return StrawchemySyncRepository(ColorType, info).create(Input(data, name="New Blue")).graphql_type()
 
     @strawberry.field
     def create_apple_color(self, info: strawberry.Info, data: ColorCreateInput) -> ColorType:
         color_input = Input(data)
         color_input.instances[0].fruits.extend(
             [
-                Fruit(name="Apple", sweetness=1, water_percent=0.5),
-                Fruit(name="Strawberry", sweetness=1, water_percent=0.5),
+                Fruit(name="New Apple", sweetness=1, water_percent=0.5),
+                Fruit(name="New Strawberry", sweetness=1, water_percent=0.5),
             ]
         )
         return StrawchemySyncRepository(ColorType, info).create(color_input).graphql_type()
@@ -683,8 +683,8 @@ class SyncMutation:
         color_input = Input(data)
         session = cast("Session", info.context.session)
         apple, strawberry = (
-            Fruit(name="Apple", sweetness=1, water_percent=0.5),
-            Fruit(name="Strawberry", sweetness=1, water_percent=0.5),
+            Fruit(name="New Apple", sweetness=1, water_percent=0.5),
+            Fruit(name="New Strawberry", sweetness=1, water_percent=0.5),
         )
         session.add_all([apple, strawberry])
         session.commit()
@@ -695,14 +695,14 @@ class SyncMutation:
     @strawberry.field
     def create_red_fruit(self, info: strawberry.Info, data: FruitCreateInput) -> FruitType:
         fruit_input = Input(data)
-        fruit_input.instances[0].color = Color(name="Red")
+        fruit_input.instances[0].color = Color(name="New Red")
         return StrawchemySyncRepository(FruitType, info).create(fruit_input).graphql_type()
 
     @strawberry.field
     def create_fruit_for_existing_color(self, info: strawberry.Info, data: FruitCreateInput) -> FruitType:
         fruit_input = Input(data)
         session = cast("Session", info.context.session)
-        red = Color(name="Red")
+        red = Color(name="New Red")
         session.add(red)
         session.commit()
         fruit_input.instances[0].color = red

--- a/tests/integration/types/sqlite.py
+++ b/tests/integration/types/sqlite.py
@@ -96,6 +96,10 @@ class UserCreate: ...
 class UserUpdateInput: ...
 
 
+@strawchemy.distinct_on(User, include="all")
+class UserDistinctOn: ...
+
+
 # Fruit
 
 
@@ -340,7 +344,10 @@ class AsyncQuery:
     # User
     user: UserType = strawchemy.field(repository_type=StrawchemyAsyncRepository)
     users: list[UserType] = strawchemy.field(
-        filter_input=UserFilter, order_by=UserOrderBy, repository_type=StrawchemyAsyncRepository
+        filter_input=UserFilter,
+        order_by=UserOrderBy,
+        repository_type=StrawchemyAsyncRepository,
+        distinct_on=UserDistinctOn,
     )
 
     # Custom resolvers
@@ -422,7 +429,10 @@ class SyncQuery:
     # User
     user: UserType = strawchemy.field(repository_type=StrawchemySyncRepository)
     users: list[UserType] = strawchemy.field(
-        filter_input=UserFilter, order_by=UserOrderBy, repository_type=StrawchemySyncRepository
+        filter_input=UserFilter,
+        order_by=UserOrderBy,
+        repository_type=StrawchemySyncRepository,
+        distinct_on=UserDistinctOn,
     )
 
     # Custom resolvers

--- a/tests/integration/types/sqlite.py
+++ b/tests/integration/types/sqlite.py
@@ -162,6 +162,14 @@ class FruitCreateInput: ...
 class FruitUpdateInput: ...
 
 
+@strawchemy.upsert_update_fields(Fruit, include="all")
+class FruitUpsertFields: ...
+
+
+@strawchemy.upsert_conflict_fields(Fruit, include="all")
+class FruitUpsertConflictFields: ...
+
+
 # Color
 
 
@@ -522,6 +530,19 @@ class AsyncMutation:
     update_fruits: list[FruitType] = strawchemy.update_by_ids(
         FruitUpdateInput, repository_type=StrawchemyAsyncRepository
     )
+    # Fruit - upsert
+    upsert_fruit: FruitType = strawchemy.upsert(
+        FruitCreateInput,
+        update_fields=FruitUpsertFields,
+        conflict_fields=FruitUpsertConflictFields,
+        repository_type=StrawchemyAsyncRepository,
+    )
+    upsert_fruits: list[FruitType] = strawchemy.upsert(
+        FruitCreateInput,
+        update_fields=FruitUpsertFields,
+        conflict_fields=FruitUpsertConflictFields,
+        repository_type=StrawchemyAsyncRepository,
+    )
     # User - Update
     update_user: UserType = strawchemy.update_by_ids(UserUpdateInput, repository_type=StrawchemyAsyncRepository)
     create_user: UserType = strawchemy.create(UserCreate, repository_type=StrawchemyAsyncRepository)
@@ -633,6 +654,19 @@ class SyncMutation:
     update_fruit: FruitType = strawchemy.update_by_ids(FruitUpdateInput, repository_type=StrawchemySyncRepository)
     update_fruits: list[FruitType] = strawchemy.update_by_ids(
         FruitUpdateInput, repository_type=StrawchemySyncRepository
+    )
+    # Fruit - upsert
+    upsert_fruit: FruitType = strawchemy.upsert(
+        FruitCreateInput,
+        update_fields=FruitUpsertFields,
+        conflict_fields=FruitUpsertConflictFields,
+        repository_type=StrawchemySyncRepository,
+    )
+    upsert_fruits: list[FruitType] = strawchemy.upsert(
+        FruitCreateInput,
+        update_fields=FruitUpsertFields,
+        conflict_fields=FruitUpsertConflictFields,
+        repository_type=StrawchemySyncRepository,
     )
     # User - Update
     update_user: UserType = strawchemy.update_by_ids(UserUpdateInput, repository_type=StrawchemySyncRepository)

--- a/tests/integration/types/sqlite.py
+++ b/tests/integration/types/sqlite.py
@@ -521,15 +521,15 @@ class AsyncMutation:
 
     @strawberry.field
     async def create_blue_color(self, info: strawberry.Info, data: ColorCreateInput) -> ColorType:
-        return (await StrawchemyAsyncRepository(ColorType, info).create(Input(data, name="Blue"))).graphql_type()
+        return (await StrawchemyAsyncRepository(ColorType, info).create(Input(data, name="New Blue"))).graphql_type()
 
     @strawberry.field
     async def create_apple_color(self, info: strawberry.Info, data: ColorCreateInput) -> ColorType:
         color_input = Input(data)
         color_input.instances[0].fruits.extend(
             [
-                Fruit(name="Apple", sweetness=1, water_percent=0.5),
-                Fruit(name="Strawberry", sweetness=1, water_percent=0.5),
+                Fruit(name="New Apple", sweetness=1, water_percent=0.5),
+                Fruit(name="New Strawberry", sweetness=1, water_percent=0.5),
             ]
         )
         return (await StrawchemyAsyncRepository(ColorType, info).create(color_input)).graphql_type()
@@ -539,8 +539,8 @@ class AsyncMutation:
         color_input = Input(data)
         session = cast("AsyncSession", info.context.session)
         apple, strawberry = (
-            Fruit(name="Apple", sweetness=1, water_percent=0.5),
-            Fruit(name="Strawberry", sweetness=1, water_percent=0.5),
+            Fruit(name="New Apple", sweetness=1, water_percent=0.5),
+            Fruit(name="New Strawberry", sweetness=1, water_percent=0.5),
         )
         session.add_all([apple, strawberry])
         await session.commit()
@@ -551,14 +551,14 @@ class AsyncMutation:
     @strawberry.field
     async def create_red_fruit(self, info: strawberry.Info, data: FruitCreateInput) -> FruitType:
         fruit_input = Input(data)
-        fruit_input.instances[0].color = Color(name="Red")
+        fruit_input.instances[0].color = Color(name="New Red")
         return (await StrawchemyAsyncRepository(FruitType, info).create(fruit_input)).graphql_type()
 
     @strawberry.field
     async def create_fruit_for_existing_color(self, info: strawberry.Info, data: FruitCreateInput) -> FruitType:
         fruit_input = Input(data)
         session = cast("AsyncSession", info.context.session)
-        red = Color(name="Red")
+        red = Color(name="New Red")
         session.add(red)
         await session.commit()
         fruit_input.instances[0].color = red
@@ -633,15 +633,15 @@ class SyncMutation:
 
     @strawberry.field
     def create_blue_color(self, info: strawberry.Info, data: ColorCreateInput) -> ColorType:
-        return StrawchemySyncRepository(ColorType, info).create(Input(data, name="Blue")).graphql_type()
+        return StrawchemySyncRepository(ColorType, info).create(Input(data, name="New Blue")).graphql_type()
 
     @strawberry.field
     def create_apple_color(self, info: strawberry.Info, data: ColorCreateInput) -> ColorType:
         color_input = Input(data)
         color_input.instances[0].fruits.extend(
             [
-                Fruit(name="Apple", sweetness=1, water_percent=0.5),
-                Fruit(name="Strawberry", sweetness=1, water_percent=0.5),
+                Fruit(name="New Apple", sweetness=1, water_percent=0.5),
+                Fruit(name="New Strawberry", sweetness=1, water_percent=0.5),
             ]
         )
         return StrawchemySyncRepository(ColorType, info).create(color_input).graphql_type()
@@ -651,8 +651,8 @@ class SyncMutation:
         color_input = Input(data)
         session = cast("Session", info.context.session)
         apple, strawberry = (
-            Fruit(name="Apple", sweetness=1, water_percent=0.5),
-            Fruit(name="Strawberry", sweetness=1, water_percent=0.5),
+            Fruit(name="New Apple", sweetness=1, water_percent=0.5),
+            Fruit(name="New Strawberry", sweetness=1, water_percent=0.5),
         )
         session.add_all([apple, strawberry])
         session.commit()
@@ -663,14 +663,14 @@ class SyncMutation:
     @strawberry.field
     def create_red_fruit(self, info: strawberry.Info, data: FruitCreateInput) -> FruitType:
         fruit_input = Input(data)
-        fruit_input.instances[0].color = Color(name="Red")
+        fruit_input.instances[0].color = Color(name="New Red")
         return StrawchemySyncRepository(FruitType, info).create(fruit_input).graphql_type()
 
     @strawberry.field
     def create_fruit_for_existing_color(self, info: strawberry.Info, data: FruitCreateInput) -> FruitType:
         fruit_input = Input(data)
         session = cast("Session", info.context.session)
-        red = Color(name="Red")
+        red = Color(name="New Red")
         session.add(red)
         session.commit()
         fruit_input.instances[0].color = red

--- a/tests/unit/__snapshots__/test_example_app/test_graphql_schema.gql
+++ b/tests/unit/__snapshots__/test_example_app/test_graphql_schema.gql
@@ -1,0 +1,1195 @@
+# serializer version: 1
+# name: test_graphql_schema
+  '''
+  """Date with time (isoformat)"""
+  scalar DateTime
+  
+  """
+  Boolean expression to compare DateTime fields. All fields are combined with logical 'AND'
+  """
+  input DateTimeComparison {
+    eq: DateTime
+    neq: DateTime
+    isNull: Boolean
+    in: [DateTime!]
+    nin: [DateTime!]
+    gt: DateTime
+    gte: DateTime
+    lt: DateTime
+    lte: DateTime
+    year: IntOrderComparison
+    month: IntOrderComparison
+    day: IntOrderComparison
+    weekDay: IntOrderComparison
+    week: IntOrderComparison
+    quarter: IntOrderComparison
+    isoYear: IntOrderComparison
+    isoWeekDay: IntOrderComparison
+    hour: IntOrderComparison
+    minute: IntOrderComparison
+    second: IntOrderComparison
+  }
+  
+  """Base interface for expected errors"""
+  interface ErrorType {
+    id: String!
+  }
+  
+  """
+  Boolean expression to compare fields supporting order comparisons. All fields are combined with logical 'AND'
+  """
+  input FloatOrderComparison {
+    eq: Float
+    neq: Float
+    isNull: Boolean
+    in: [Float!]
+    nin: [Float!]
+    gt: Float
+    gte: Float
+    lt: Float
+    lte: Float
+  }
+  
+  """
+  Boolean expression to compare fields supporting order comparisons. All fields are combined with logical 'AND'
+  """
+  input IntOrderComparison {
+    eq: Int
+    neq: Int
+    isNull: Boolean
+    in: [Int!]
+    nin: [Int!]
+    gt: Int
+    gte: Int
+    lt: Int
+    lte: Int
+  }
+  
+  """Indicate validation error type and location."""
+  type LocalizedErrorType implements ErrorType {
+    id: String!
+    loc: [String!]!
+    message: String!
+    type: String!
+  }
+  
+  """
+  Boolean expression to compare aggregated fields. All fields are combined with logical 'AND'.
+  """
+  input MilestoneAggregateBoolExp {
+    count: MilestoneAggregateBoolExpCount
+    maxDatetime: MilestoneAggregateBoolExpMaxdatetime
+    maxString: MilestoneAggregateBoolExpMaxstring
+    minDatetime: MilestoneAggregateBoolExpMindatetime
+    minString: MilestoneAggregateBoolExpMinstring
+    sum: MilestoneAggregateBoolExpSum
+  }
+  
+  """Boolean expression to compare count aggregation."""
+  input MilestoneAggregateBoolExpCount {
+    arguments: [MilestoneCountFields!] = []
+    predicate: IntOrderComparison!
+    distinct: Boolean = false
+  }
+  
+  """Boolean expression to compare max aggregation."""
+  input MilestoneAggregateBoolExpMaxdatetime {
+    arguments: [MilestoneMinMaxDateTimeFieldsEnum!]!
+    predicate: DateTimeComparison!
+    distinct: Boolean = false
+  }
+  
+  """Boolean expression to compare max aggregation."""
+  input MilestoneAggregateBoolExpMaxstring {
+    arguments: [MilestoneMinMaxStringFieldsEnum!]!
+    predicate: TextComparison!
+    distinct: Boolean = false
+  }
+  
+  """Boolean expression to compare min aggregation."""
+  input MilestoneAggregateBoolExpMindatetime {
+    arguments: [MilestoneMinMaxDateTimeFieldsEnum!]!
+    predicate: DateTimeComparison!
+    distinct: Boolean = false
+  }
+  
+  """Boolean expression to compare min aggregation."""
+  input MilestoneAggregateBoolExpMinstring {
+    arguments: [MilestoneMinMaxStringFieldsEnum!]!
+    predicate: TextComparison!
+    distinct: Boolean = false
+  }
+  
+  """Boolean expression to compare sum aggregation."""
+  input MilestoneAggregateBoolExpSum {
+    arguments: [MilestoneSumFieldsEnum!]!
+    predicate: FloatOrderComparison!
+    distinct: Boolean = false
+  }
+  
+  input MilestoneAggregateMinMaxDatetimeFieldsOrderBy {
+    createdAt: OrderByEnum!
+    updatedAt: OrderByEnum!
+  }
+  
+  input MilestoneAggregateMinMaxStringFieldsOrderBy {
+    name: OrderByEnum!
+  }
+  
+  input MilestoneAggregateNumericFieldsOrderBy {
+    name: OrderByEnum!
+  }
+  
+  input MilestoneAggregateOrderBy {
+    count: OrderByEnum
+    maxDatetime: MilestoneAggregateMinMaxDatetimeFieldsOrderBy
+    maxString: MilestoneAggregateMinMaxStringFieldsOrderBy
+    minDatetime: MilestoneAggregateMinMaxDatetimeFieldsOrderBy
+    minString: MilestoneAggregateMinMaxStringFieldsOrderBy
+    sum: MilestoneAggregateNumericFieldsOrderBy
+  }
+  
+  """
+  Boolean expression to compare fields. All fields are combined with logical 'AND'.
+  """
+  input MilestoneBoolExp {
+    _and: [MilestoneBoolExp!]! = []
+    _or: [MilestoneBoolExp!]! = []
+    _not: MilestoneBoolExp
+    projectsAggregate: ProjectAggregateBoolExp
+    projects: ProjectBoolExp
+    name: TextComparison
+    id: UUIDGenericComparison
+    createdAt: DateTimeComparison
+    updatedAt: DateTimeComparison
+  }
+  
+  enum MilestoneCountFields {
+    name
+    id
+    createdAt
+    updatedAt
+  }
+  
+  """GraphQL create input type"""
+  input MilestoneCreate {
+    projects: MilestoneProjectsIdFieldsInputMilestoneProjectInputMilestoneProjectsUpdateFieldsMilestoneProjectsConflictFieldsToManyCreateInput
+    name: String!
+    id: UUID
+  }
+  
+  enum MilestoneMinMaxDateTimeFieldsEnum {
+    createdAt
+    updatedAt
+  }
+  
+  enum MilestoneMinMaxStringFieldsEnum {
+    name
+  }
+  
+  """
+  Boolean expression to compare fields. All fields are combined with logical 'AND'.
+  """
+  input MilestoneOrderBy {
+    projectsAggregate: ProjectAggregateOrderBy
+    projects: ProjectOrderBy
+    name: OrderByEnum
+    id: OrderByEnum
+    createdAt: OrderByEnum
+    updatedAt: OrderByEnum
+  }
+  
+  """GraphQL create input type"""
+  input MilestoneProjectInput {
+    tickets: MilestoneTicketsIdFieldsInputMilestoneTicketInputMilestoneTicketsUpdateFieldsMilestoneTicketsConflictFieldsToManyCreateInput
+    tag: MilestoneTagIdFieldsInputMilestoneTagInputMilestoneTagUpdateFieldsMilestoneTagConflictFieldsToOneInput = null
+    name: String!
+    id: UUID
+  }
+  
+  """Conflict fields enum"""
+  enum MilestoneProjectsConflictFields {
+    id
+  }
+  
+  """Identifier input"""
+  input MilestoneProjectsIdFieldsInput {
+    id: UUID!
+  }
+  
+  """Add new or existing objects"""
+  input MilestoneProjectsIdFieldsInputMilestoneProjectInputMilestoneProjectsUpdateFieldsMilestoneProjectsConflictFieldsToManyCreateInput {
+    set: [MilestoneProjectsIdFieldsInput!]
+    add: [MilestoneProjectsIdFieldsInput!]
+    create: [MilestoneProjectInput!]
+    upsert: MilestoneProjectsIdFieldsInputMilestoneProjectInputMilestoneProjectsUpdateFieldsMilestoneProjectsConflictFieldsToManyUpsertInput
+  }
+  
+  """Add new objects or update if existing"""
+  input MilestoneProjectsIdFieldsInputMilestoneProjectInputMilestoneProjectsUpdateFieldsMilestoneProjectsConflictFieldsToManyUpsertInput {
+    create: [MilestoneProjectInput!]!
+    conflictFields: MilestoneProjectsConflictFields!
+    updateFields: [MilestoneProjectsUpdateFields!]
+  }
+  
+  """Update fields enum"""
+  enum MilestoneProjectsUpdateFields {
+    milestoneId
+    tagId
+    name
+    id
+  }
+  
+  enum MilestoneSumFieldsEnum {
+    name
+  }
+  
+  """Conflict fields enum"""
+  enum MilestoneTagConflictFields {
+    id
+  }
+  
+  """Identifier input"""
+  input MilestoneTagIdFieldsInput {
+    id: UUID!
+  }
+  
+  """Add a new or existing object"""
+  input MilestoneTagIdFieldsInputMilestoneTagInputMilestoneTagUpdateFieldsMilestoneTagConflictFieldsToOneInput {
+    set: MilestoneTagIdFieldsInput
+    create: MilestoneTagInput
+    upsert: MilestoneTagIdFieldsInputMilestoneTagInputMilestoneTagUpdateFieldsMilestoneTagConflictFieldsToOneUpsertInput
+  }
+  
+  """Add new object or update if existing"""
+  input MilestoneTagIdFieldsInputMilestoneTagInputMilestoneTagUpdateFieldsMilestoneTagConflictFieldsToOneUpsertInput {
+    create: MilestoneTagInput!
+    conflictFields: MilestoneTagConflictFields
+    updateFields: [MilestoneTagUpdateFields!]
+  }
+  
+  """GraphQL create input type"""
+  input MilestoneTagInput {
+    name: String!
+    id: UUID
+  }
+  
+  """Update fields enum"""
+  enum MilestoneTagUpdateFields {
+    name
+    id
+  }
+  
+  """GraphQL create input type"""
+  input MilestoneTicketInput {
+    name: String!
+    id: UUID
+  }
+  
+  """Conflict fields enum"""
+  enum MilestoneTicketsConflictFields {
+    id
+  }
+  
+  """Identifier input"""
+  input MilestoneTicketsIdFieldsInput {
+    id: UUID!
+  }
+  
+  """Add new or existing objects"""
+  input MilestoneTicketsIdFieldsInputMilestoneTicketInputMilestoneTicketsUpdateFieldsMilestoneTicketsConflictFieldsToManyCreateInput {
+    set: [MilestoneTicketsIdFieldsInput!]
+    add: [MilestoneTicketsIdFieldsInput!]
+    create: [MilestoneTicketInput!]
+    upsert: MilestoneTicketsIdFieldsInputMilestoneTicketInputMilestoneTicketsUpdateFieldsMilestoneTicketsConflictFieldsToManyUpsertInput
+  }
+  
+  """Add new objects or update if existing"""
+  input MilestoneTicketsIdFieldsInputMilestoneTicketInputMilestoneTicketsUpdateFieldsMilestoneTicketsConflictFieldsToManyUpsertInput {
+    create: [MilestoneTicketInput!]!
+    conflictFields: MilestoneTicketsConflictFields!
+    updateFields: [MilestoneTicketsUpdateFields!]
+  }
+  
+  """Update fields enum"""
+  enum MilestoneTicketsUpdateFields {
+    name
+    projectId
+    id
+  }
+  
+  """GraphQL type"""
+  type MilestoneType {
+    projectsAggregate: ProjectAggregate!
+  
+    """Fetch objects from the ProjectType collection"""
+    projects(filter: ProjectFilter = null, orderBy: [ProjectOrder!] = null): [ProjectType!]!
+    name: String!
+    id: UUID!
+    createdAt: DateTime!
+    updatedAt: DateTime!
+  }
+  
+  type Mutation {
+    """Fetch object from the TicketType collection by id"""
+    createTicket(data: TicketCreate!): TicketTypeValidationErrorType!
+  
+    """Fetch objects from the TicketType collection"""
+    createTickets(data: [TicketCreate!]!): [TicketType!]!
+  
+    """Fetch object from the TicketType collection by id"""
+    upsertTicket(updateFields: [TicketUpsertFields!] = null, conflictFields: TicketUpsertConflictFields = null, data: TicketCreate!): TicketType!
+  
+    """Fetch object from the ProjectType collection by id"""
+    createProject(data: ProjectCreate!): ProjectType!
+  
+    """Fetch objects from the ProjectType collection"""
+    createProjects(data: [ProjectCreate!]!): [ProjectType!]!
+  
+    """Fetch object from the MilestoneType collection by id"""
+    createMilestone(data: MilestoneCreate!): MilestoneType!
+  
+    """Fetch object from the TicketType collection by id"""
+    updateTicketsByIds(data: TicketUpdate!, filter: TicketFilter = null): TicketType!
+  
+    """Fetch objects from the TicketType collection"""
+    updateTickets(data: TicketPartial!, filter: TicketFilter = null): [TicketType!]!
+  
+    """Fetch objects from the TicketType collection"""
+    deleteTicket(filter: TicketFilter!): [TicketType!]!
+  }
+  
+  enum OrderByEnum {
+    ASC
+    ASC_NULLS_FIRST
+    ASC_NULLS_LAST
+    DESC
+    DESC_NULLS_FIRST
+    DESC_NULLS_LAST
+  }
+  
+  """Aggregation fields"""
+  type ProjectAggregate {
+    count: Int
+    max: ProjectMinMaxFields!
+    min: ProjectMinMaxFields!
+    sum: ProjectSumFields!
+  }
+  
+  """
+  Boolean expression to compare aggregated fields. All fields are combined with logical 'AND'.
+  """
+  input ProjectAggregateBoolExp {
+    count: ProjectAggregateBoolExpCount
+    maxDatetime: ProjectAggregateBoolExpMaxdatetime
+    maxString: ProjectAggregateBoolExpMaxstring
+    minDatetime: ProjectAggregateBoolExpMindatetime
+    minString: ProjectAggregateBoolExpMinstring
+    sum: ProjectAggregateBoolExpSum
+  }
+  
+  """Boolean expression to compare count aggregation."""
+  input ProjectAggregateBoolExpCount {
+    arguments: [ProjectCountFields!] = []
+    predicate: IntOrderComparison!
+    distinct: Boolean = false
+  }
+  
+  """Boolean expression to compare max aggregation."""
+  input ProjectAggregateBoolExpMaxdatetime {
+    arguments: [ProjectMinMaxDateTimeFieldsEnum!]!
+    predicate: DateTimeComparison!
+    distinct: Boolean = false
+  }
+  
+  """Boolean expression to compare max aggregation."""
+  input ProjectAggregateBoolExpMaxstring {
+    arguments: [ProjectMinMaxStringFieldsEnum!]!
+    predicate: TextComparison!
+    distinct: Boolean = false
+  }
+  
+  """Boolean expression to compare min aggregation."""
+  input ProjectAggregateBoolExpMindatetime {
+    arguments: [ProjectMinMaxDateTimeFieldsEnum!]!
+    predicate: DateTimeComparison!
+    distinct: Boolean = false
+  }
+  
+  """Boolean expression to compare min aggregation."""
+  input ProjectAggregateBoolExpMinstring {
+    arguments: [ProjectMinMaxStringFieldsEnum!]!
+    predicate: TextComparison!
+    distinct: Boolean = false
+  }
+  
+  """Boolean expression to compare sum aggregation."""
+  input ProjectAggregateBoolExpSum {
+    arguments: [ProjectSumFieldsEnum!]!
+    predicate: FloatOrderComparison!
+    distinct: Boolean = false
+  }
+  
+  input ProjectAggregateMinMaxDatetimeFieldsOrderBy {
+    createdAt: OrderByEnum!
+    updatedAt: OrderByEnum!
+  }
+  
+  input ProjectAggregateMinMaxStringFieldsOrderBy {
+    name: OrderByEnum!
+  }
+  
+  input ProjectAggregateNumericFieldsOrderBy {
+    name: OrderByEnum!
+  }
+  
+  input ProjectAggregateOrderBy {
+    count: OrderByEnum
+    maxDatetime: ProjectAggregateMinMaxDatetimeFieldsOrderBy
+    maxString: ProjectAggregateMinMaxStringFieldsOrderBy
+    minDatetime: ProjectAggregateMinMaxDatetimeFieldsOrderBy
+    minString: ProjectAggregateMinMaxStringFieldsOrderBy
+    sum: ProjectAggregateNumericFieldsOrderBy
+  }
+  
+  """
+  Boolean expression to compare fields. All fields are combined with logical 'AND'.
+  """
+  input ProjectBoolExp {
+    _and: [ProjectBoolExp!]! = []
+    _or: [ProjectBoolExp!]! = []
+    _not: ProjectBoolExp
+    ticketsAggregate: TicketAggregateBoolExp
+    tickets: TicketFilter
+    milestoneAggregate: MilestoneAggregateBoolExp
+    milestone: MilestoneBoolExp
+    tagAggregate: TagAggregateBoolExp
+    tag: TagBoolExp
+    milestoneId: UUIDGenericComparison
+    tagId: UUIDGenericComparison
+    name: TextComparison
+    id: UUIDGenericComparison
+    createdAt: DateTimeComparison
+    updatedAt: DateTimeComparison
+  }
+  
+  enum ProjectCountFields {
+    milestoneId
+    tagId
+    name
+    id
+    createdAt
+    updatedAt
+  }
+  
+  """GraphQL create input type"""
+  input ProjectCreate {
+    tickets: ProjectTicketsIdFieldsInputProjectTicketInputProjectTicketsUpdateFieldsProjectTicketsConflictFieldsToManyCreateInput
+    milestone: ProjectMilestoneIdFieldsInputProjectMilestoneInputProjectMilestoneUpdateFieldsProjectMilestoneConflictFieldsToOneInput = null
+    tag: ProjectTagIdFieldsInputProjectTagInputProjectTagUpdateFieldsProjectTagConflictFieldsToOneInput = null
+    name: String!
+    id: UUID
+  }
+  
+  """
+  Boolean expression to compare fields. All fields are combined with logical 'AND'.
+  """
+  input ProjectFilter {
+    _and: [ProjectFilter!]! = []
+    _or: [ProjectFilter!]! = []
+    not_: ProjectFilter
+    ticketsAggregate: TicketAggregateBoolExp
+    tickets: TicketFilter
+    milestoneAggregate: MilestoneAggregateBoolExp
+    milestone: MilestoneBoolExp
+    tagAggregate: TagAggregateBoolExp
+    tag: TagBoolExp
+    milestoneId: UUIDGenericComparison
+    tagId: UUIDGenericComparison
+    name: TextComparison
+    id: UUIDGenericComparison
+    createdAt: DateTimeComparison
+    updatedAt: DateTimeComparison
+  }
+  
+  """Conflict fields enum"""
+  enum ProjectMilestoneConflictFields {
+    id
+  }
+  
+  """Identifier input"""
+  input ProjectMilestoneIdFieldsInput {
+    id: UUID!
+  }
+  
+  """Add a new or existing object"""
+  input ProjectMilestoneIdFieldsInputProjectMilestoneInputProjectMilestoneUpdateFieldsProjectMilestoneConflictFieldsToOneInput {
+    set: ProjectMilestoneIdFieldsInput
+    create: ProjectMilestoneInput
+    upsert: ProjectMilestoneIdFieldsInputProjectMilestoneInputProjectMilestoneUpdateFieldsProjectMilestoneConflictFieldsToOneUpsertInput
+  }
+  
+  """Add new object or update if existing"""
+  input ProjectMilestoneIdFieldsInputProjectMilestoneInputProjectMilestoneUpdateFieldsProjectMilestoneConflictFieldsToOneUpsertInput {
+    create: ProjectMilestoneInput!
+    conflictFields: ProjectMilestoneConflictFields
+    updateFields: [ProjectMilestoneUpdateFields!]
+  }
+  
+  """GraphQL create input type"""
+  input ProjectMilestoneInput {
+    name: String!
+    id: UUID
+  }
+  
+  """Update fields enum"""
+  enum ProjectMilestoneUpdateFields {
+    name
+    id
+  }
+  
+  enum ProjectMinMaxDateTimeFieldsEnum {
+    createdAt
+    updatedAt
+  }
+  
+  """GraphQL type"""
+  type ProjectMinMaxFields {
+    name: String
+    createdAt: DateTime
+    updatedAt: DateTime
+  }
+  
+  enum ProjectMinMaxStringFieldsEnum {
+    name
+  }
+  
+  """
+  Boolean expression to compare fields. All fields are combined with logical 'AND'.
+  """
+  input ProjectOrder {
+    ticketsAggregate: TicketAggregateOrderBy
+    tickets: TicketOrder
+    milestoneAggregate: MilestoneAggregateOrderBy
+    milestone: MilestoneOrderBy
+    tagAggregate: TagAggregateOrderBy
+    tag: TagOrderBy
+    milestoneId: OrderByEnum
+    tagId: OrderByEnum
+    name: OrderByEnum
+    id: OrderByEnum
+    createdAt: OrderByEnum
+    updatedAt: OrderByEnum
+  }
+  
+  """
+  Boolean expression to compare fields. All fields are combined with logical 'AND'.
+  """
+  input ProjectOrderBy {
+    ticketsAggregate: TicketAggregateOrderBy
+    tickets: TicketOrder
+    milestoneAggregate: MilestoneAggregateOrderBy
+    milestone: MilestoneOrderBy
+    tagAggregate: TagAggregateOrderBy
+    tag: TagOrderBy
+    milestoneId: OrderByEnum
+    tagId: OrderByEnum
+    name: OrderByEnum
+    id: OrderByEnum
+    createdAt: OrderByEnum
+    updatedAt: OrderByEnum
+  }
+  
+  """GraphQL type"""
+  type ProjectSumFields {
+    name: String
+  }
+  
+  enum ProjectSumFieldsEnum {
+    name
+  }
+  
+  """Conflict fields enum"""
+  enum ProjectTagConflictFields {
+    id
+  }
+  
+  """Identifier input"""
+  input ProjectTagIdFieldsInput {
+    id: UUID!
+  }
+  
+  """Add a new or existing object"""
+  input ProjectTagIdFieldsInputProjectTagInputProjectTagUpdateFieldsProjectTagConflictFieldsToOneInput {
+    set: ProjectTagIdFieldsInput
+    create: ProjectTagInput
+    upsert: ProjectTagIdFieldsInputProjectTagInputProjectTagUpdateFieldsProjectTagConflictFieldsToOneUpsertInput
+  }
+  
+  """Add new object or update if existing"""
+  input ProjectTagIdFieldsInputProjectTagInputProjectTagUpdateFieldsProjectTagConflictFieldsToOneUpsertInput {
+    create: ProjectTagInput!
+    conflictFields: ProjectTagConflictFields
+    updateFields: [ProjectTagUpdateFields!]
+  }
+  
+  """GraphQL create input type"""
+  input ProjectTagInput {
+    name: String!
+    id: UUID
+  }
+  
+  """Update fields enum"""
+  enum ProjectTagUpdateFields {
+    name
+    id
+  }
+  
+  """GraphQL create input type"""
+  input ProjectTicketInput {
+    name: String!
+    id: UUID
+  }
+  
+  """Conflict fields enum"""
+  enum ProjectTicketsConflictFields {
+    id
+  }
+  
+  """Identifier input"""
+  input ProjectTicketsIdFieldsInput {
+    id: UUID!
+  }
+  
+  """Add new or existing objects"""
+  input ProjectTicketsIdFieldsInputProjectTicketInputProjectTicketsUpdateFieldsProjectTicketsConflictFieldsToManyCreateInput {
+    set: [ProjectTicketsIdFieldsInput!]
+    add: [ProjectTicketsIdFieldsInput!]
+    create: [ProjectTicketInput!]
+    upsert: ProjectTicketsIdFieldsInputProjectTicketInputProjectTicketsUpdateFieldsProjectTicketsConflictFieldsToManyUpsertInput
+  }
+  
+  """Add new objects or update if existing"""
+  input ProjectTicketsIdFieldsInputProjectTicketInputProjectTicketsUpdateFieldsProjectTicketsConflictFieldsToManyUpsertInput {
+    create: [ProjectTicketInput!]!
+    conflictFields: ProjectTicketsConflictFields!
+    updateFields: [ProjectTicketsUpdateFields!]
+  }
+  
+  """Update fields enum"""
+  enum ProjectTicketsUpdateFields {
+    name
+    projectId
+    id
+  }
+  
+  """GraphQL type"""
+  type ProjectType {
+    ticketsAggregate: TicketAggregate!
+  
+    """Fetch objects from the TicketType collection"""
+    tickets(filter: TicketFilter = null, orderBy: [TicketOrder!] = null): [TicketType!]!
+    milestone: MilestoneType
+    tag: TagType
+    milestoneId: UUID
+    tagId: UUID
+    name: String!
+    id: UUID!
+    createdAt: DateTime!
+    updatedAt: DateTime!
+  }
+  
+  type Query {
+    """Fetch object from the TicketType collection by id"""
+    ticket(id: UUID!): TicketType!
+  
+    """Fetch objects from the TicketType collection"""
+    tickets(filter: TicketFilter = null, orderBy: [TicketOrder!] = null): [TicketType!]!
+  
+    """Fetch object from the ProjectType collection by id"""
+    project(id: UUID!): ProjectType!
+  
+    """Fetch objects from the ProjectType collection"""
+    projects(filter: ProjectFilter = null, orderBy: [ProjectOrder!] = null): [ProjectType!]!
+  
+    """Fetch objects from the MilestoneType collection"""
+    milestones: [MilestoneType!]!
+  }
+  
+  """
+  Boolean expression to compare aggregated fields. All fields are combined with logical 'AND'.
+  """
+  input TagAggregateBoolExp {
+    count: TagAggregateBoolExpCount
+    maxDatetime: TagAggregateBoolExpMaxdatetime
+    maxString: TagAggregateBoolExpMaxstring
+    minDatetime: TagAggregateBoolExpMindatetime
+    minString: TagAggregateBoolExpMinstring
+    sum: TagAggregateBoolExpSum
+  }
+  
+  """Boolean expression to compare count aggregation."""
+  input TagAggregateBoolExpCount {
+    arguments: [TagCountFields!] = []
+    predicate: IntOrderComparison!
+    distinct: Boolean = false
+  }
+  
+  """Boolean expression to compare max aggregation."""
+  input TagAggregateBoolExpMaxdatetime {
+    arguments: [TagMinMaxDateTimeFieldsEnum!]!
+    predicate: DateTimeComparison!
+    distinct: Boolean = false
+  }
+  
+  """Boolean expression to compare max aggregation."""
+  input TagAggregateBoolExpMaxstring {
+    arguments: [TagMinMaxStringFieldsEnum!]!
+    predicate: TextComparison!
+    distinct: Boolean = false
+  }
+  
+  """Boolean expression to compare min aggregation."""
+  input TagAggregateBoolExpMindatetime {
+    arguments: [TagMinMaxDateTimeFieldsEnum!]!
+    predicate: DateTimeComparison!
+    distinct: Boolean = false
+  }
+  
+  """Boolean expression to compare min aggregation."""
+  input TagAggregateBoolExpMinstring {
+    arguments: [TagMinMaxStringFieldsEnum!]!
+    predicate: TextComparison!
+    distinct: Boolean = false
+  }
+  
+  """Boolean expression to compare sum aggregation."""
+  input TagAggregateBoolExpSum {
+    arguments: [TagSumFieldsEnum!]!
+    predicate: FloatOrderComparison!
+    distinct: Boolean = false
+  }
+  
+  input TagAggregateMinMaxDatetimeFieldsOrderBy {
+    createdAt: OrderByEnum!
+    updatedAt: OrderByEnum!
+  }
+  
+  input TagAggregateMinMaxStringFieldsOrderBy {
+    name: OrderByEnum!
+  }
+  
+  input TagAggregateNumericFieldsOrderBy {
+    name: OrderByEnum!
+  }
+  
+  input TagAggregateOrderBy {
+    count: OrderByEnum
+    maxDatetime: TagAggregateMinMaxDatetimeFieldsOrderBy
+    maxString: TagAggregateMinMaxStringFieldsOrderBy
+    minDatetime: TagAggregateMinMaxDatetimeFieldsOrderBy
+    minString: TagAggregateMinMaxStringFieldsOrderBy
+    sum: TagAggregateNumericFieldsOrderBy
+  }
+  
+  """
+  Boolean expression to compare fields. All fields are combined with logical 'AND'.
+  """
+  input TagBoolExp {
+    _and: [TagBoolExp!]! = []
+    _or: [TagBoolExp!]! = []
+    _not: TagBoolExp
+    name: TextComparison
+    id: UUIDGenericComparison
+    createdAt: DateTimeComparison
+    updatedAt: DateTimeComparison
+  }
+  
+  enum TagCountFields {
+    name
+    id
+    createdAt
+    updatedAt
+  }
+  
+  enum TagMinMaxDateTimeFieldsEnum {
+    createdAt
+    updatedAt
+  }
+  
+  enum TagMinMaxStringFieldsEnum {
+    name
+  }
+  
+  """
+  Boolean expression to compare fields. All fields are combined with logical 'AND'.
+  """
+  input TagOrderBy {
+    name: OrderByEnum
+    id: OrderByEnum
+    createdAt: OrderByEnum
+    updatedAt: OrderByEnum
+  }
+  
+  enum TagSumFieldsEnum {
+    name
+  }
+  
+  """GraphQL type"""
+  type TagType {
+    name: String!
+    id: UUID!
+    createdAt: DateTime!
+    updatedAt: DateTime!
+  }
+  
+  """
+  Boolean expression to compare String fields. All fields are combined with logical 'AND'
+  """
+  input TextComparison {
+    eq: String
+    neq: String
+    isNull: Boolean
+    in: [String!]
+    nin: [String!]
+    gt: String
+    gte: String
+    lt: String
+    lte: String
+    like: String
+    nlike: String
+    ilike: String
+    nilike: String
+    regexp: String
+    iregexp: String
+    nregexp: String
+    inregexp: String
+    startswith: String
+    endswith: String
+    contains: String
+    istartswith: String
+    iendswith: String
+    icontains: String
+  }
+  
+  """Aggregation fields"""
+  type TicketAggregate {
+    count: Int
+    max: TicketMinMaxFields!
+    min: TicketMinMaxFields!
+    sum: TicketSumFields!
+  }
+  
+  """
+  Boolean expression to compare aggregated fields. All fields are combined with logical 'AND'.
+  """
+  input TicketAggregateBoolExp {
+    count: TicketAggregateBoolExpCount
+    maxDatetime: TicketAggregateBoolExpMaxdatetime
+    maxString: TicketAggregateBoolExpMaxstring
+    minDatetime: TicketAggregateBoolExpMindatetime
+    minString: TicketAggregateBoolExpMinstring
+    sum: TicketAggregateBoolExpSum
+  }
+  
+  """Boolean expression to compare count aggregation."""
+  input TicketAggregateBoolExpCount {
+    arguments: [TicketCountFields!] = []
+    predicate: IntOrderComparison!
+    distinct: Boolean = false
+  }
+  
+  """Boolean expression to compare max aggregation."""
+  input TicketAggregateBoolExpMaxdatetime {
+    arguments: [TicketMinMaxDateTimeFieldsEnum!]!
+    predicate: DateTimeComparison!
+    distinct: Boolean = false
+  }
+  
+  """Boolean expression to compare max aggregation."""
+  input TicketAggregateBoolExpMaxstring {
+    arguments: [TicketMinMaxStringFieldsEnum!]!
+    predicate: TextComparison!
+    distinct: Boolean = false
+  }
+  
+  """Boolean expression to compare min aggregation."""
+  input TicketAggregateBoolExpMindatetime {
+    arguments: [TicketMinMaxDateTimeFieldsEnum!]!
+    predicate: DateTimeComparison!
+    distinct: Boolean = false
+  }
+  
+  """Boolean expression to compare min aggregation."""
+  input TicketAggregateBoolExpMinstring {
+    arguments: [TicketMinMaxStringFieldsEnum!]!
+    predicate: TextComparison!
+    distinct: Boolean = false
+  }
+  
+  """Boolean expression to compare sum aggregation."""
+  input TicketAggregateBoolExpSum {
+    arguments: [TicketSumFieldsEnum!]!
+    predicate: FloatOrderComparison!
+    distinct: Boolean = false
+  }
+  
+  input TicketAggregateMinMaxDatetimeFieldsOrderBy {
+    createdAt: OrderByEnum!
+    updatedAt: OrderByEnum!
+  }
+  
+  input TicketAggregateMinMaxStringFieldsOrderBy {
+    name: OrderByEnum!
+  }
+  
+  input TicketAggregateNumericFieldsOrderBy {
+    name: OrderByEnum!
+  }
+  
+  input TicketAggregateOrderBy {
+    count: OrderByEnum
+    maxDatetime: TicketAggregateMinMaxDatetimeFieldsOrderBy
+    maxString: TicketAggregateMinMaxStringFieldsOrderBy
+    minDatetime: TicketAggregateMinMaxDatetimeFieldsOrderBy
+    minString: TicketAggregateMinMaxStringFieldsOrderBy
+    sum: TicketAggregateNumericFieldsOrderBy
+  }
+  
+  enum TicketCountFields {
+    name
+    projectId
+    id
+    createdAt
+    updatedAt
+  }
+  
+  """GraphQL create input type"""
+  input TicketCreate {
+    project: TicketProjectIdFieldsInputTicketProjectInputTicketProjectUpdateFieldsTicketProjectConflictFieldsToOneInput = null
+    name: String!
+    id: UUID
+  }
+  
+  """
+  Boolean expression to compare fields. All fields are combined with logical 'AND'.
+  """
+  input TicketFilter {
+    _and: [TicketFilter!]! = []
+    _or: [TicketFilter!]! = []
+    _not: TicketFilter
+    projectAggregate: ProjectAggregateBoolExp
+    project: ProjectBoolExp
+    name: TextComparison
+    projectId: UUIDGenericComparison
+    id: UUIDGenericComparison
+    createdAt: DateTimeComparison
+    updatedAt: DateTimeComparison
+  }
+  
+  """Conflict fields enum"""
+  enum TicketMilestoneConflictFields {
+    id
+  }
+  
+  """Identifier input"""
+  input TicketMilestoneIdFieldsInput {
+    id: UUID!
+  }
+  
+  """Add a new or existing object"""
+  input TicketMilestoneIdFieldsInputTicketMilestoneInputTicketMilestoneUpdateFieldsTicketMilestoneConflictFieldsToOneInput {
+    set: TicketMilestoneIdFieldsInput
+    create: TicketMilestoneInput
+    upsert: TicketMilestoneIdFieldsInputTicketMilestoneInputTicketMilestoneUpdateFieldsTicketMilestoneConflictFieldsToOneUpsertInput
+  }
+  
+  """Add new object or update if existing"""
+  input TicketMilestoneIdFieldsInputTicketMilestoneInputTicketMilestoneUpdateFieldsTicketMilestoneConflictFieldsToOneUpsertInput {
+    create: TicketMilestoneInput!
+    conflictFields: TicketMilestoneConflictFields
+    updateFields: [TicketMilestoneUpdateFields!]
+  }
+  
+  """GraphQL create input type"""
+  input TicketMilestoneInput {
+    name: String!
+    id: UUID
+  }
+  
+  """Update fields enum"""
+  enum TicketMilestoneUpdateFields {
+    name
+    id
+  }
+  
+  enum TicketMinMaxDateTimeFieldsEnum {
+    createdAt
+    updatedAt
+  }
+  
+  """GraphQL type"""
+  type TicketMinMaxFields {
+    name: String
+    createdAt: DateTime
+    updatedAt: DateTime
+  }
+  
+  enum TicketMinMaxStringFieldsEnum {
+    name
+  }
+  
+  """
+  Boolean expression to compare fields. All fields are combined with logical 'AND'.
+  """
+  input TicketOrder {
+    projectAggregate: ProjectAggregateOrderBy
+    project: ProjectOrderBy
+    name: OrderByEnum
+    projectId: OrderByEnum
+    id: OrderByEnum
+    createdAt: OrderByEnum
+    updatedAt: OrderByEnum
+  }
+  
+  """GraphQL update_by_filter input type"""
+  input TicketPartial {
+    project: TicketProjectIdFieldsInputTicketProjectInputTicketProjectUpdateFieldsTicketProjectConflictFieldsToOneInput
+    name: String
+    id: UUID
+  }
+  
+  """Conflict fields enum"""
+  enum TicketProjectConflictFields {
+    id
+  }
+  
+  """Identifier input"""
+  input TicketProjectIdFieldsInput {
+    id: UUID!
+  }
+  
+  """Add a new or existing object"""
+  input TicketProjectIdFieldsInputTicketProjectInputTicketProjectUpdateFieldsTicketProjectConflictFieldsToOneInput {
+    set: TicketProjectIdFieldsInput
+    create: TicketProjectInput
+    upsert: TicketProjectIdFieldsInputTicketProjectInputTicketProjectUpdateFieldsTicketProjectConflictFieldsToOneUpsertInput
+  }
+  
+  """Add new object or update if existing"""
+  input TicketProjectIdFieldsInputTicketProjectInputTicketProjectUpdateFieldsTicketProjectConflictFieldsToOneUpsertInput {
+    create: TicketProjectInput!
+    conflictFields: TicketProjectConflictFields
+    updateFields: [TicketProjectUpdateFields!]
+  }
+  
+  """GraphQL create input type"""
+  input TicketProjectInput {
+    milestone: TicketMilestoneIdFieldsInputTicketMilestoneInputTicketMilestoneUpdateFieldsTicketMilestoneConflictFieldsToOneInput = null
+    tag: TicketTagIdFieldsInputTicketTagInputTicketTagUpdateFieldsTicketTagConflictFieldsToOneInput = null
+    name: String!
+    id: UUID
+  }
+  
+  """Update fields enum"""
+  enum TicketProjectUpdateFields {
+    milestoneId
+    tagId
+    name
+    id
+  }
+  
+  """GraphQL type"""
+  type TicketSumFields {
+    name: String
+  }
+  
+  enum TicketSumFieldsEnum {
+    name
+  }
+  
+  """Conflict fields enum"""
+  enum TicketTagConflictFields {
+    id
+  }
+  
+  """Identifier input"""
+  input TicketTagIdFieldsInput {
+    id: UUID!
+  }
+  
+  """Add a new or existing object"""
+  input TicketTagIdFieldsInputTicketTagInputTicketTagUpdateFieldsTicketTagConflictFieldsToOneInput {
+    set: TicketTagIdFieldsInput
+    create: TicketTagInput
+    upsert: TicketTagIdFieldsInputTicketTagInputTicketTagUpdateFieldsTicketTagConflictFieldsToOneUpsertInput
+  }
+  
+  """Add new object or update if existing"""
+  input TicketTagIdFieldsInputTicketTagInputTicketTagUpdateFieldsTicketTagConflictFieldsToOneUpsertInput {
+    create: TicketTagInput!
+    conflictFields: TicketTagConflictFields
+    updateFields: [TicketTagUpdateFields!]
+  }
+  
+  """GraphQL create input type"""
+  input TicketTagInput {
+    name: String!
+    id: UUID
+  }
+  
+  """Update fields enum"""
+  enum TicketTagUpdateFields {
+    name
+    id
+  }
+  
+  """GraphQL type"""
+  type TicketType {
+    project: ProjectType
+    name: String!
+    projectId: UUID
+    id: UUID!
+    createdAt: DateTime!
+    updatedAt: DateTime!
+  }
+  
+  union TicketTypeValidationErrorType = TicketType | ValidationErrorType
+  
+  """GraphQL update_by_pk input type"""
+  input TicketUpdate {
+    project: TicketProjectIdFieldsInputTicketProjectInputTicketProjectUpdateFieldsTicketProjectConflictFieldsToOneInput
+    name: String
+    id: UUID!
+  }
+  
+  enum TicketUpsertConflictFields {
+    id
+  }
+  
+  enum TicketUpsertFields {
+    name
+    projectId
+    id
+  }
+  
+  scalar UUID
+  
+  """
+  Boolean expression to compare fields supporting equality comparisons. All fields are combined with logical 'AND'
+  """
+  input UUIDGenericComparison {
+    eq: UUID
+    neq: UUID
+    isNull: Boolean
+    in: [UUID!]
+    nin: [UUID!]
+  }
+  
+  """Input is malformed or invalid."""
+  type ValidationErrorType implements ErrorType {
+    id: String!
+    errors: [LocalizedErrorType!]!
+  }
+  '''
+# ---

--- a/tests/unit/mapping/__snapshots__/test_types/test_mutation_schemas[create_mutation].gql
+++ b/tests/unit/mapping/__snapshots__/test_types/test_mutation_schemas[create_mutation].gql
@@ -67,22 +67,41 @@
     sum: GroupSumFields!
   }
   
+  """Update fields enum"""
+  enum GroupColorConflictFields {
+    id
+  }
+  
   """Identifier input"""
   input GroupColorIdFieldsInput {
     id: UUID!
   }
   
   """Add a new or existing object"""
-  input GroupColorIdFieldsInputGroupColorInputRequiredToOneInput {
+  input GroupColorIdFieldsInputGroupColorInputGroupColorUpdateFieldsGroupColorConflictFieldsRequiredToOneInput {
     set: GroupColorIdFieldsInput
     create: GroupColorInput
+    upsert: GroupColorIdFieldsInputGroupColorInputGroupColorUpdateFieldsGroupColorConflictFieldsToOneUpsertInput
+  }
+  
+  """Add new object or update if existing"""
+  input GroupColorIdFieldsInputGroupColorInputGroupColorUpdateFieldsGroupColorConflictFieldsToOneUpsertInput {
+    create: GroupColorInput!
+    conflictFields: GroupColorConflictFields
+    updateFields: [GroupColorUpdateFields!]
   }
   
   """GraphQL create input type"""
   input GroupColorInput {
-    fruits: GroupFruitsIdFieldsInputGroupFruitInputToManyCreateInput
+    fruits: GroupFruitsIdFieldsInputGroupFruitInputGroupFruitsUpdateFieldsGroupFruitsConflictFieldsToManyCreateInput
     name: String!
     id: UUID
+  }
+  
+  """Update fields enum"""
+  enum GroupColorUpdateFields {
+    name
+    id
   }
   
   """GraphQL create input type"""
@@ -92,23 +111,44 @@
     id: UUID
   }
   
+  """Update fields enum"""
+  enum GroupFruitsConflictFields {
+    id
+  }
+  
   """Identifier input"""
   input GroupFruitsIdFieldsInput {
     id: UUID!
   }
   
   """Add new or existing objects"""
-  input GroupFruitsIdFieldsInputGroupFruitInputToManyCreateInput {
+  input GroupFruitsIdFieldsInputGroupFruitInputGroupFruitsUpdateFieldsGroupFruitsConflictFieldsToManyCreateInput {
     set: [GroupFruitsIdFieldsInput!]
     add: [GroupFruitsIdFieldsInput!]
     create: [GroupFruitInput!]
+    upsert: GroupFruitsIdFieldsInputGroupFruitInputGroupFruitsUpdateFieldsGroupFruitsConflictFieldsToManyUpsertInput
+  }
+  
+  """Add new objects or update if existing"""
+  input GroupFruitsIdFieldsInputGroupFruitInputGroupFruitsUpdateFieldsGroupFruitsConflictFieldsToManyUpsertInput {
+    create: [GroupFruitInput!]!
+    conflictFields: GroupFruitsConflictFields!
+    updateFields: [GroupFruitsUpdateFields!]
+  }
+  
+  """Update fields enum"""
+  enum GroupFruitsUpdateFields {
+    name
+    colorId
+    sweetness
+    id
   }
   
   """GraphQL create input type"""
   input GroupInput {
-    tag: GroupTagIdFieldsInputGroupTagInputRequiredToOneInput!
-    users: GroupUsersIdFieldsInputGroupUserInputToManyCreateInput
-    color: GroupColorIdFieldsInputGroupColorInputRequiredToOneInput!
+    tag: GroupTagIdFieldsInputGroupTagInputGroupTagUpdateFieldsGroupTagConflictFieldsRequiredToOneInput!
+    users: GroupUsersIdFieldsInputGroupUserInputGroupUsersUpdateFieldsGroupUsersConflictFieldsToManyCreateInput
+    color: GroupColorIdFieldsInputGroupColorInputGroupColorUpdateFieldsGroupColorConflictFieldsRequiredToOneInput!
     name: String!
     id: UUID
   }
@@ -123,27 +163,47 @@
     name: String
   }
   
+  """Update fields enum"""
+  enum GroupTagConflictFields {
+    id
+  }
+  
   """Identifier input"""
   input GroupTagIdFieldsInput {
     id: UUID!
   }
   
   """Add a new or existing object"""
-  input GroupTagIdFieldsInputGroupTagInputRequiredToOneInput {
+  input GroupTagIdFieldsInputGroupTagInputGroupTagUpdateFieldsGroupTagConflictFieldsRequiredToOneInput {
     set: GroupTagIdFieldsInput
     create: GroupTagInput
+    upsert: GroupTagIdFieldsInputGroupTagInputGroupTagUpdateFieldsGroupTagConflictFieldsToOneUpsertInput
   }
   
   """Add a new or existing object"""
-  input GroupTagIdFieldsInputGroupTagInputToOneInput {
+  input GroupTagIdFieldsInputGroupTagInputGroupTagUpdateFieldsGroupTagConflictFieldsToOneInput {
     set: GroupTagIdFieldsInput
     create: GroupTagInput
+    upsert: GroupTagIdFieldsInputGroupTagInputGroupTagUpdateFieldsGroupTagConflictFieldsToOneUpsertInput
+  }
+  
+  """Add new object or update if existing"""
+  input GroupTagIdFieldsInputGroupTagInputGroupTagUpdateFieldsGroupTagConflictFieldsToOneUpsertInput {
+    create: GroupTagInput!
+    conflictFields: GroupTagConflictFields
+    updateFields: [GroupTagUpdateFields!]
   }
   
   """GraphQL create input type"""
   input GroupTagInput {
     name: String!
     id: UUID
+  }
+  
+  """Update fields enum"""
+  enum GroupTagUpdateFields {
+    name
+    id
   }
   
   """GraphQL type"""
@@ -162,9 +222,14 @@
   
   """GraphQL create input type"""
   input GroupUserInput {
-    tag: GroupTagIdFieldsInputGroupTagInputToOneInput = null
+    tag: GroupTagIdFieldsInputGroupTagInputGroupTagUpdateFieldsGroupTagConflictFieldsToOneInput = null
     name: String!
     id: UUID
+  }
+  
+  """Update fields enum"""
+  enum GroupUsersConflictFields {
+    id
   }
   
   """Identifier input"""
@@ -173,10 +238,26 @@
   }
   
   """Add new or existing objects"""
-  input GroupUsersIdFieldsInputGroupUserInputToManyCreateInput {
+  input GroupUsersIdFieldsInputGroupUserInputGroupUsersUpdateFieldsGroupUsersConflictFieldsToManyCreateInput {
     set: [GroupUsersIdFieldsInput!]
     add: [GroupUsersIdFieldsInput!]
     create: [GroupUserInput!]
+    upsert: GroupUsersIdFieldsInputGroupUserInputGroupUsersUpdateFieldsGroupUsersConflictFieldsToManyUpsertInput
+  }
+  
+  """Add new objects or update if existing"""
+  input GroupUsersIdFieldsInputGroupUserInputGroupUsersUpdateFieldsGroupUsersConflictFieldsToManyUpsertInput {
+    create: [GroupUserInput!]!
+    conflictFields: GroupUsersConflictFields!
+    updateFields: [GroupUsersUpdateFields!]
+  }
+  
+  """Update fields enum"""
+  enum GroupUsersUpdateFields {
+    name
+    groupId
+    tagId
+    id
   }
   
   """

--- a/tests/unit/mapping/__snapshots__/test_types/test_mutation_schemas[create_mutation].gql
+++ b/tests/unit/mapping/__snapshots__/test_types/test_mutation_schemas[create_mutation].gql
@@ -67,7 +67,7 @@
     sum: GroupSumFields!
   }
   
-  """Update fields enum"""
+  """Conflict fields enum"""
   enum GroupColorConflictFields {
     id
   }
@@ -111,7 +111,7 @@
     id: UUID
   }
   
-  """Update fields enum"""
+  """Conflict fields enum"""
   enum GroupFruitsConflictFields {
     id
   }
@@ -163,7 +163,7 @@
     name: String
   }
   
-  """Update fields enum"""
+  """Conflict fields enum"""
   enum GroupTagConflictFields {
     id
   }
@@ -227,7 +227,7 @@
     id: UUID
   }
   
-  """Update fields enum"""
+  """Conflict fields enum"""
   enum GroupUsersConflictFields {
     id
   }

--- a/tests/unit/mapping/__snapshots__/test_types/test_mutation_schemas[update_mutation].gql
+++ b/tests/unit/mapping/__snapshots__/test_types/test_mutation_schemas[update_mutation].gql
@@ -317,7 +317,7 @@
     distinct: Boolean = false
   }
   
-  """Update fields enum"""
+  """Conflict fields enum"""
   enum GroupColorConflictFields {
     id
   }
@@ -387,7 +387,7 @@
     id: UUID!
   }
   
-  """Update fields enum"""
+  """Conflict fields enum"""
   enum GroupFruitsConflictFields {
     id
   }
@@ -448,7 +448,7 @@
     name
   }
   
-  """Update fields enum"""
+  """Conflict fields enum"""
   enum GroupTagConflictFields {
     id
   }
@@ -521,7 +521,7 @@
     id: UUID!
   }
   
-  """Update fields enum"""
+  """Conflict fields enum"""
   enum GroupUsersConflictFields {
     id
   }
@@ -689,7 +689,7 @@
     id: UUIDGenericComparison
   }
   
-  """Update fields enum"""
+  """Conflict fields enum"""
   enum TagColorConflictFields {
     id
   }
@@ -738,7 +738,7 @@
     id: UUID!
   }
   
-  """Update fields enum"""
+  """Conflict fields enum"""
   enum TagFruitsConflictFields {
     id
   }
@@ -780,7 +780,7 @@
     id: UUID!
   }
   
-  """Update fields enum"""
+  """Conflict fields enum"""
   enum TagGroupsConflictFields {
     id
   }
@@ -821,7 +821,7 @@
     name
   }
   
-  """Update fields enum"""
+  """Conflict fields enum"""
   enum TagTagConflictFields {
     id
   }
@@ -875,7 +875,7 @@
     id: UUID!
   }
   
-  """Update fields enum"""
+  """Conflict fields enum"""
   enum TagUsersConflictFields {
     id
   }

--- a/tests/unit/mapping/__snapshots__/test_types/test_mutation_schemas[update_mutation].gql
+++ b/tests/unit/mapping/__snapshots__/test_types/test_mutation_schemas[update_mutation].gql
@@ -317,22 +317,41 @@
     distinct: Boolean = false
   }
   
+  """Update fields enum"""
+  enum GroupColorConflictFields {
+    id
+  }
+  
   """Identifier input"""
   input GroupColorIdFieldsInput {
     id: UUID!
   }
   
   """Add a new or existing object"""
-  input GroupColorIdFieldsInputGroupColorInputRequiredToOneInput {
+  input GroupColorIdFieldsInputGroupColorInputGroupColorUpdateFieldsGroupColorConflictFieldsRequiredToOneInput {
     set: GroupColorIdFieldsInput
     create: GroupColorInput
+    upsert: GroupColorIdFieldsInputGroupColorInputGroupColorUpdateFieldsGroupColorConflictFieldsToOneUpsertInput
+  }
+  
+  """Add new object or update if existing"""
+  input GroupColorIdFieldsInputGroupColorInputGroupColorUpdateFieldsGroupColorConflictFieldsToOneUpsertInput {
+    create: GroupColorInput!
+    conflictFields: GroupColorConflictFields
+    updateFields: [GroupColorUpdateFields!]
   }
   
   """GraphQL update_by_pk input type"""
   input GroupColorInput {
-    fruits: GroupFruitsIdFieldsInputGroupFruitInputToManyUpdateInput
+    fruits: GroupFruitsIdFieldsInputGroupFruitInputGroupFruitsUpdateFieldsGroupFruitsConflictFieldsToManyUpdateInput
     name: String
     id: UUID!
+  }
+  
+  """Update fields enum"""
+  enum GroupColorUpdateFields {
+    name
+    id
   }
   
   enum GroupCountFields {
@@ -368,17 +387,38 @@
     id: UUID!
   }
   
+  """Update fields enum"""
+  enum GroupFruitsConflictFields {
+    id
+  }
+  
   """Identifier input"""
   input GroupFruitsIdFieldsInput {
     id: UUID!
   }
   
   """Add new objects or update existing ones"""
-  input GroupFruitsIdFieldsInputGroupFruitInputToManyUpdateInput {
+  input GroupFruitsIdFieldsInputGroupFruitInputGroupFruitsUpdateFieldsGroupFruitsConflictFieldsToManyUpdateInput {
     set: [GroupFruitsIdFieldsInput!]
     add: [GroupFruitsIdFieldsInput!]
     create: [GroupFruitInput!]
+    upsert: GroupFruitsIdFieldsInputGroupFruitInputGroupFruitsUpdateFieldsGroupFruitsConflictFieldsToManyUpsertInput
     remove: [GroupFruitsIdFieldsInput!]
+  }
+  
+  """Add new objects or update if existing"""
+  input GroupFruitsIdFieldsInputGroupFruitInputGroupFruitsUpdateFieldsGroupFruitsConflictFieldsToManyUpsertInput {
+    create: [GroupFruitInput!]!
+    conflictFields: GroupFruitsConflictFields!
+    updateFields: [GroupFruitsUpdateFields!]
+  }
+  
+  """Update fields enum"""
+  enum GroupFruitsUpdateFields {
+    name
+    colorId
+    sweetness
+    id
   }
   
   """GraphQL type"""
@@ -392,9 +432,9 @@
   
   """GraphQL update_by_filter input type"""
   input GroupPartial {
-    tag: GroupTagIdFieldsInputGroupTagInputRequiredToOneInput
-    users: GroupUsersIdFieldsInputGroupUserInputToManyUpdateInput
-    color: GroupColorIdFieldsInputGroupColorInputRequiredToOneInput
+    tag: GroupTagIdFieldsInputGroupTagInputGroupTagUpdateFieldsGroupTagConflictFieldsRequiredToOneInput
+    users: GroupUsersIdFieldsInputGroupUserInputGroupUsersUpdateFieldsGroupUsersConflictFieldsToManyUpdateInput
+    color: GroupColorIdFieldsInputGroupColorInputGroupColorUpdateFieldsGroupColorConflictFieldsRequiredToOneInput
     name: String
     id: UUID
   }
@@ -408,27 +448,47 @@
     name
   }
   
+  """Update fields enum"""
+  enum GroupTagConflictFields {
+    id
+  }
+  
   """Identifier input"""
   input GroupTagIdFieldsInput {
     id: UUID!
   }
   
   """Add a new or existing object"""
-  input GroupTagIdFieldsInputGroupTagInputRequiredToOneInput {
+  input GroupTagIdFieldsInputGroupTagInputGroupTagUpdateFieldsGroupTagConflictFieldsRequiredToOneInput {
     set: GroupTagIdFieldsInput
     create: GroupTagInput
+    upsert: GroupTagIdFieldsInputGroupTagInputGroupTagUpdateFieldsGroupTagConflictFieldsToOneUpsertInput
   }
   
   """Add a new or existing object"""
-  input GroupTagIdFieldsInputGroupTagInputToOneInput {
+  input GroupTagIdFieldsInputGroupTagInputGroupTagUpdateFieldsGroupTagConflictFieldsToOneInput {
     set: GroupTagIdFieldsInput
     create: GroupTagInput
+    upsert: GroupTagIdFieldsInputGroupTagInputGroupTagUpdateFieldsGroupTagConflictFieldsToOneUpsertInput
+  }
+  
+  """Add new object or update if existing"""
+  input GroupTagIdFieldsInputGroupTagInputGroupTagUpdateFieldsGroupTagConflictFieldsToOneUpsertInput {
+    create: GroupTagInput!
+    conflictFields: GroupTagConflictFields
+    updateFields: [GroupTagUpdateFields!]
   }
   
   """GraphQL update_by_pk input type"""
   input GroupTagInput {
     name: String
     id: UUID!
+  }
+  
+  """Update fields enum"""
+  enum GroupTagUpdateFields {
+    name
+    id
   }
   
   """GraphQL type"""
@@ -447,18 +507,23 @@
   
   """GraphQL update_by_pk input type"""
   input GroupUpdate {
-    tag: GroupTagIdFieldsInputGroupTagInputRequiredToOneInput
-    users: GroupUsersIdFieldsInputGroupUserInputToManyUpdateInput
-    color: GroupColorIdFieldsInputGroupColorInputRequiredToOneInput
+    tag: GroupTagIdFieldsInputGroupTagInputGroupTagUpdateFieldsGroupTagConflictFieldsRequiredToOneInput
+    users: GroupUsersIdFieldsInputGroupUserInputGroupUsersUpdateFieldsGroupUsersConflictFieldsToManyUpdateInput
+    color: GroupColorIdFieldsInputGroupColorInputGroupColorUpdateFieldsGroupColorConflictFieldsRequiredToOneInput
     name: String
     id: UUID!
   }
   
   """GraphQL update_by_pk input type"""
   input GroupUserInput {
-    tag: GroupTagIdFieldsInputGroupTagInputToOneInput
+    tag: GroupTagIdFieldsInputGroupTagInputGroupTagUpdateFieldsGroupTagConflictFieldsToOneInput
     name: String
     id: UUID!
+  }
+  
+  """Update fields enum"""
+  enum GroupUsersConflictFields {
+    id
   }
   
   """Identifier input"""
@@ -467,11 +532,27 @@
   }
   
   """Add new objects or update existing ones"""
-  input GroupUsersIdFieldsInputGroupUserInputToManyUpdateInput {
+  input GroupUsersIdFieldsInputGroupUserInputGroupUsersUpdateFieldsGroupUsersConflictFieldsToManyUpdateInput {
     set: [GroupUsersIdFieldsInput!]
     add: [GroupUsersIdFieldsInput!]
     create: [GroupUserInput!]
+    upsert: GroupUsersIdFieldsInputGroupUserInputGroupUsersUpdateFieldsGroupUsersConflictFieldsToManyUpsertInput
     remove: [GroupUsersIdFieldsInput!]
+  }
+  
+  """Add new objects or update if existing"""
+  input GroupUsersIdFieldsInputGroupUserInputGroupUsersUpdateFieldsGroupUsersConflictFieldsToManyUpsertInput {
+    create: [GroupUserInput!]!
+    conflictFields: GroupUsersConflictFields!
+    updateFields: [GroupUsersUpdateFields!]
+  }
+  
+  """Update fields enum"""
+  enum GroupUsersUpdateFields {
+    name
+    groupId
+    tagId
+    id
   }
   
   """
@@ -608,22 +689,41 @@
     id: UUIDGenericComparison
   }
   
+  """Update fields enum"""
+  enum TagColorConflictFields {
+    id
+  }
+  
   """Identifier input"""
   input TagColorIdFieldsInput {
     id: UUID!
   }
   
   """Add a new or existing object"""
-  input TagColorIdFieldsInputTagColorInputRequiredToOneInput {
+  input TagColorIdFieldsInputTagColorInputTagColorUpdateFieldsTagColorConflictFieldsRequiredToOneInput {
     set: TagColorIdFieldsInput
     create: TagColorInput
+    upsert: TagColorIdFieldsInputTagColorInputTagColorUpdateFieldsTagColorConflictFieldsToOneUpsertInput
+  }
+  
+  """Add new object or update if existing"""
+  input TagColorIdFieldsInputTagColorInputTagColorUpdateFieldsTagColorConflictFieldsToOneUpsertInput {
+    create: TagColorInput!
+    conflictFields: TagColorConflictFields
+    updateFields: [TagColorUpdateFields!]
   }
   
   """GraphQL update_by_pk input type"""
   input TagColorInput {
-    fruits: TagFruitsIdFieldsInputTagFruitInputToManyUpdateInput
+    fruits: TagFruitsIdFieldsInputTagFruitInputTagFruitsUpdateFieldsTagFruitsConflictFieldsToManyUpdateInput
     name: String
     id: UUID!
+  }
+  
+  """Update fields enum"""
+  enum TagColorUpdateFields {
+    name
+    id
   }
   
   enum TagCountFields {
@@ -638,25 +738,51 @@
     id: UUID!
   }
   
+  """Update fields enum"""
+  enum TagFruitsConflictFields {
+    id
+  }
+  
   """Identifier input"""
   input TagFruitsIdFieldsInput {
     id: UUID!
   }
   
   """Add new objects or update existing ones"""
-  input TagFruitsIdFieldsInputTagFruitInputToManyUpdateInput {
+  input TagFruitsIdFieldsInputTagFruitInputTagFruitsUpdateFieldsTagFruitsConflictFieldsToManyUpdateInput {
     set: [TagFruitsIdFieldsInput!]
     add: [TagFruitsIdFieldsInput!]
     create: [TagFruitInput!]
+    upsert: TagFruitsIdFieldsInputTagFruitInputTagFruitsUpdateFieldsTagFruitsConflictFieldsToManyUpsertInput
     remove: [TagFruitsIdFieldsInput!]
+  }
+  
+  """Add new objects or update if existing"""
+  input TagFruitsIdFieldsInputTagFruitInputTagFruitsUpdateFieldsTagFruitsConflictFieldsToManyUpsertInput {
+    create: [TagFruitInput!]!
+    conflictFields: TagFruitsConflictFields!
+    updateFields: [TagFruitsUpdateFields!]
+  }
+  
+  """Update fields enum"""
+  enum TagFruitsUpdateFields {
+    name
+    colorId
+    sweetness
+    id
   }
   
   """GraphQL update_by_pk input type"""
   input TagGroupInput {
-    users: TagUsersIdFieldsInputTagUserInputToManyUpdateInput
-    color: TagColorIdFieldsInputTagColorInputRequiredToOneInput
+    users: TagUsersIdFieldsInputTagUserInputTagUsersUpdateFieldsTagUsersConflictFieldsToManyUpdateInput
+    color: TagColorIdFieldsInputTagColorInputTagColorUpdateFieldsTagColorConflictFieldsRequiredToOneInput
     name: String
     id: UUID!
+  }
+  
+  """Update fields enum"""
+  enum TagGroupsConflictFields {
+    id
   }
   
   """Identifier input"""
@@ -665,10 +791,26 @@
   }
   
   """Add new objects or update existing ones"""
-  input TagGroupsIdFieldsInputTagGroupInputRequiredToManyUpdateInput {
+  input TagGroupsIdFieldsInputTagGroupInputTagGroupsUpdateFieldsTagGroupsConflictFieldsRequiredToManyUpdateInput {
     set: [TagGroupsIdFieldsInput!]
     add: [TagGroupsIdFieldsInput!]
     create: [TagGroupInput!]
+    upsert: TagGroupsIdFieldsInputTagGroupInputTagGroupsUpdateFieldsTagGroupsConflictFieldsToManyUpsertInput
+  }
+  
+  """Add new objects or update if existing"""
+  input TagGroupsIdFieldsInputTagGroupInputTagGroupsUpdateFieldsTagGroupsConflictFieldsToManyUpsertInput {
+    create: [TagGroupInput!]!
+    conflictFields: TagGroupsConflictFields!
+    updateFields: [TagGroupsUpdateFields!]
+  }
+  
+  """Update fields enum"""
+  enum TagGroupsUpdateFields {
+    name
+    tagId
+    colorId
+    id
   }
   
   enum TagMinMaxStringFieldsEnum {
@@ -679,15 +821,34 @@
     name
   }
   
+  """Update fields enum"""
+  enum TagTagConflictFields {
+    id
+  }
+  
   """Identifier input"""
   input TagTagIdFieldsInput {
     id: UUID!
   }
   
   """Add a new or existing object"""
-  input TagTagIdFieldsInputTagUpdateToOneInput {
+  input TagTagIdFieldsInputTagUpdateTagTagUpdateFieldsTagTagConflictFieldsToOneInput {
     set: TagTagIdFieldsInput
     create: TagUpdate
+    upsert: TagTagIdFieldsInputTagUpdateTagTagUpdateFieldsTagTagConflictFieldsToOneUpsertInput
+  }
+  
+  """Add new object or update if existing"""
+  input TagTagIdFieldsInputTagUpdateTagTagUpdateFieldsTagTagConflictFieldsToOneUpsertInput {
+    create: TagUpdate!
+    conflictFields: TagTagConflictFields
+    updateFields: [TagTagUpdateFields!]
+  }
+  
+  """Update fields enum"""
+  enum TagTagUpdateFields {
+    name
+    id
   }
   
   """GraphQL type"""
@@ -702,16 +863,21 @@
   
   """GraphQL update_by_pk input type"""
   input TagUpdate {
-    groups: TagGroupsIdFieldsInputTagGroupInputRequiredToManyUpdateInput
+    groups: TagGroupsIdFieldsInputTagGroupInputTagGroupsUpdateFieldsTagGroupsConflictFieldsRequiredToManyUpdateInput
     name: String
     id: UUID!
   }
   
   """GraphQL update_by_pk input type"""
   input TagUserInput {
-    tag: TagTagIdFieldsInputTagUpdateToOneInput
+    tag: TagTagIdFieldsInputTagUpdateTagTagUpdateFieldsTagTagConflictFieldsToOneInput
     name: String
     id: UUID!
+  }
+  
+  """Update fields enum"""
+  enum TagUsersConflictFields {
+    id
   }
   
   """Identifier input"""
@@ -720,11 +886,27 @@
   }
   
   """Add new objects or update existing ones"""
-  input TagUsersIdFieldsInputTagUserInputToManyUpdateInput {
+  input TagUsersIdFieldsInputTagUserInputTagUsersUpdateFieldsTagUsersConflictFieldsToManyUpdateInput {
     set: [TagUsersIdFieldsInput!]
     add: [TagUsersIdFieldsInput!]
     create: [TagUserInput!]
+    upsert: TagUsersIdFieldsInputTagUserInputTagUsersUpdateFieldsTagUsersConflictFieldsToManyUpsertInput
     remove: [TagUsersIdFieldsInput!]
+  }
+  
+  """Add new objects or update if existing"""
+  input TagUsersIdFieldsInputTagUserInputTagUsersUpdateFieldsTagUsersConflictFieldsToManyUpsertInput {
+    create: [TagUserInput!]!
+    conflictFields: TagUsersConflictFields!
+    updateFields: [TagUsersUpdateFields!]
+  }
+  
+  """Update fields enum"""
+  enum TagUsersUpdateFields {
+    name
+    groupId
+    tagId
+    id
   }
   
   """

--- a/tests/unit/mapping/__snapshots__/test_types/test_query_and_mutations.gql
+++ b/tests/unit/mapping/__snapshots__/test_types/test_query_and_mutations.gql
@@ -8,7 +8,7 @@
     id: UUID
   }
   
-  """Update fields enum"""
+  """Conflict fields enum"""
   enum ColorFruitsConflictFields {
     id
   }
@@ -71,7 +71,7 @@
     varSamp: FruitNumericFields!
   }
   
-  """Update fields enum"""
+  """Conflict fields enum"""
   enum FruitColorConflictFields {
     id
   }

--- a/tests/unit/mapping/__snapshots__/test_types/test_query_and_mutations.gql
+++ b/tests/unit/mapping/__snapshots__/test_types/test_query_and_mutations.gql
@@ -8,21 +8,42 @@
     id: UUID
   }
   
+  """Update fields enum"""
+  enum ColorFruitsConflictFields {
+    id
+  }
+  
   """Identifier input"""
   input ColorFruitsIdFieldsInput {
     id: UUID!
   }
   
   """Add new or existing objects"""
-  input ColorFruitsIdFieldsInputColorFruitInputToManyCreateInput {
+  input ColorFruitsIdFieldsInputColorFruitInputColorFruitsUpdateFieldsColorFruitsConflictFieldsToManyCreateInput {
     set: [ColorFruitsIdFieldsInput!]
     add: [ColorFruitsIdFieldsInput!]
     create: [ColorFruitInput!]
+    upsert: ColorFruitsIdFieldsInputColorFruitInputColorFruitsUpdateFieldsColorFruitsConflictFieldsToManyUpsertInput
+  }
+  
+  """Add new objects or update if existing"""
+  input ColorFruitsIdFieldsInputColorFruitInputColorFruitsUpdateFieldsColorFruitsConflictFieldsToManyUpsertInput {
+    create: [ColorFruitInput!]!
+    conflictFields: ColorFruitsConflictFields!
+    updateFields: [ColorFruitsUpdateFields!]
+  }
+  
+  """Update fields enum"""
+  enum ColorFruitsUpdateFields {
+    name
+    colorId
+    sweetness
+    id
   }
   
   """GraphQL create input type"""
   input ColorInput {
-    fruits: ColorFruitsIdFieldsInputColorFruitInputToManyCreateInput
+    fruits: ColorFruitsIdFieldsInputColorFruitInputColorFruitsUpdateFieldsColorFruitsConflictFieldsToManyCreateInput
     name: String!
     id: UUID
   }
@@ -50,15 +71,28 @@
     varSamp: FruitNumericFields!
   }
   
+  """Update fields enum"""
+  enum FruitColorConflictFields {
+    id
+  }
+  
   """Identifier input"""
   input FruitColorIdFieldsInput {
     id: UUID!
   }
   
   """Add a new or existing object"""
-  input FruitColorIdFieldsInputFruitColorInputToOneInput {
+  input FruitColorIdFieldsInputFruitColorInputFruitColorUpdateFieldsFruitColorConflictFieldsToOneInput {
     set: FruitColorIdFieldsInput
     create: FruitColorInput
+    upsert: FruitColorIdFieldsInputFruitColorInputFruitColorUpdateFieldsFruitColorConflictFieldsToOneUpsertInput
+  }
+  
+  """Add new object or update if existing"""
+  input FruitColorIdFieldsInputFruitColorInputFruitColorUpdateFieldsFruitColorConflictFieldsToOneUpsertInput {
+    create: FruitColorInput!
+    conflictFields: FruitColorConflictFields
+    updateFields: [FruitColorUpdateFields!]
   }
   
   """GraphQL create input type"""
@@ -67,9 +101,15 @@
     id: UUID
   }
   
+  """Update fields enum"""
+  enum FruitColorUpdateFields {
+    name
+    id
+  }
+  
   """GraphQL create input type"""
   input FruitInput {
-    color: FruitColorIdFieldsInputFruitColorInputToOneInput = null
+    color: FruitColorIdFieldsInputFruitColorInputFruitColorUpdateFieldsFruitColorConflictFieldsToOneInput = null
     name: String!
     sweetness: Int!
     id: UUID

--- a/tests/unit/test_example_app.py
+++ b/tests/unit/test_example_app.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import textwrap
+from typing import TYPE_CHECKING
+
+import pytest
+from examples.testapp.testapp.app import create_app
+
+if TYPE_CHECKING:
+    from syrupy.assertion import SnapshotAssertion
+
+
+def test_asgi() -> None:
+    create_app()
+
+
+@pytest.mark.snapshot
+def test_graphql_schema(graphql_snapshot: SnapshotAssertion) -> None:
+    from examples.testapp.testapp.schema import schema
+
+    assert textwrap.dedent(str(schema)).strip() == graphql_snapshot

--- a/uv.lock
+++ b/uv.lock
@@ -2537,6 +2537,7 @@ test = [
     { name = "pytest-xdist" },
     { name = "sqlparse" },
     { name = "syrupy" },
+    { name = "testapp" },
 ]
 
 [package.metadata]
@@ -2619,6 +2620,7 @@ test = [
     { name = "pytest-xdist" },
     { name = "sqlparse" },
     { name = "syrupy" },
+    { name = "testapp", editable = "examples/testapp" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2642,6 +2642,7 @@ source = { editable = "examples/testapp" }
 dependencies = [
     { name = "aiosqlite" },
     { name = "litestar", extra = ["sqlalchemy", "standard"] },
+    { name = "pydantic" },
     { name = "sqlalchemy" },
     { name = "strawberry-graphql" },
 ]
@@ -2650,6 +2651,7 @@ dependencies = [
 requires-dist = [
     { name = "aiosqlite" },
     { name = "litestar", extras = ["sqlalchemy", "standard"] },
+    { name = "pydantic" },
     { name = "sqlalchemy" },
     { name = "strawberry-graphql" },
 ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

- Closes #38

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Implement initial upsert support by extending the GraphQL API and underlying SQLAlchemy repository to perform insert-or-update mutations. Provide configurable update_fields and conflict_fields for precise conflict handling, integrate native upsert SQL for each dialect, update DTO and input factories, document usage in the README, and add comprehensive tests.

New Features:
- Introduce root-level upsert GraphQL mutations supporting insert-or-update behavior
- Enable nested upsert operations within to-one and to-many relationship inputs
- Expose update_fields and conflict_fields enums for customizable conflict resolution

Enhancements:
- Extend SQLAlchemy repository to generate dialect-specific upsert statements (ON CONFLICT/ON DUPLICATE KEY)
- Introduce InsertData and MutationData abstractions to unify insert, update, and upsert flows
- Expand Strawberry mapper and DTO factories to generate upsert-related input types and enums
- Add new StrawchemyUpsertMutationField and strawchemy.upsert helper for upsert mutations

Documentation:
- Add Upsert Mutations section to README with examples of root and nested upsert usage

Tests:
- Add integration tests covering root-level, to-one, and to-many upsert scenarios