### PR TITLE
fix(schema): fix recursive fields include/exclude logic when a relation is explicitly included

### DIFF
--- a/src/strawchemy/dto/base.py
+++ b/src/strawchemy/dto/base.py
@@ -414,12 +414,17 @@ class DTOFactory(Generic[ModelT, ModelFieldT, DTOBaseT]):
         explictly_excluded = node.is_root and field.model_field_name in dto_config.exclude
         explicitly_included = node.is_root and field.model_field_name in dto_config.include
 
+        # Exclude fields not present in init if purpose is write
         if dto_config.purpose is Purpose.WRITE and not explicitly_included:
             explictly_excluded = explictly_excluded or not field.init
         if dto_config.include == "all" and not explictly_excluded:
             explicitly_included = True
 
-        excluded = (explictly_excluded or not explicitly_included) or dto_config.purpose not in field.allowed_purposes
+        excluded = dto_config.purpose not in field.allowed_purposes
+        if node.is_root:
+            excluded = excluded or (explictly_excluded or not explicitly_included)
+        else:
+            excluded = excluded or explictly_excluded
         return not has_override and excluded
 
     def _resolve_basic_type(self, field: DTOFieldDefinition[ModelT, ModelFieldT], dto_config: DTOConfig) -> Any:

--- a/src/strawchemy/strawberry/factories/types.py
+++ b/src/strawchemy/strawberry/factories/types.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import dataclasses
 from collections.abc import Generator
 from typing import TYPE_CHECKING, Any, Self, TypeVar, override
 
@@ -366,7 +365,7 @@ class AggregateDTOFactory(GraphQLDTOFactory[AggregateDTOT]):
     ) -> type[AggregateDTOT]:
         field_map = field_map if field_map is not None else {}
         model_field = parent_field_def.model_field if parent_field_def else None
-        as_partial_config = dataclasses.replace(dto_config, partial=True)
+        aggregate_config = dto_config.copy_with(partial=True, include="all")
         field_definitions: list[FunctionFieldDefinition] = [
             FunctionFieldDefinition(
                 dto_config=dto_config,
@@ -377,7 +376,7 @@ class AggregateDTOFactory(GraphQLDTOFactory[AggregateDTOT]):
                 _function=aggregation,
                 default=aggregation.default,
             )
-            for aggregation in self._aggregation_builder.output_functions(model, as_partial_config)
+            for aggregation in self._aggregation_builder.output_functions(model, aggregate_config)
         ]
 
         root_key = DTOKey.from_dto_node(node)

--- a/tests/unit/mapping/__snapshots__/test_schemas/test_query_schemas[exclude_and_override_field].gql
+++ b/tests/unit/mapping/__snapshots__/test_schemas/test_query_schemas[exclude_and_override_field].gql
@@ -26,6 +26,7 @@
   
   """GraphQL type"""
   type FruitMinMaxFields {
+    name: String
     sweetness: Int
   }
   
@@ -36,6 +37,7 @@
   
   """GraphQL type"""
   type FruitSumFields {
+    name: String
     sweetness: Int
   }
   

--- a/tests/unit/mapping/__snapshots__/test_schemas/test_query_schemas[exclude_and_override_type].gql
+++ b/tests/unit/mapping/__snapshots__/test_schemas/test_query_schemas[exclude_and_override_type].gql
@@ -26,6 +26,7 @@
   
   """GraphQL type"""
   type FruitMinMaxFields {
+    name: String
     sweetness: Int
   }
   
@@ -36,6 +37,7 @@
   
   """GraphQL type"""
   type FruitSumFields {
+    name: String
     sweetness: Int
   }
   

--- a/tests/unit/mapping/__snapshots__/test_schemas/test_query_schemas[include_explicit].gql
+++ b/tests/unit/mapping/__snapshots__/test_schemas/test_query_schemas[include_explicit].gql
@@ -2,13 +2,61 @@
 # name: test_query_schemas[include_explicit]
   '''
   """GraphQL type"""
+  type ColorType {
+    fruitsAggregate: FruitAggregate!
+  
+    """Fetch objects from the FruitWithColorType collection"""
+    fruits: [FruitWithColorType!]!
+    name: String!
+    id: UUID!
+  }
+  
+  """Aggregation fields"""
+  type FruitAggregate {
+    avg: FruitNumericFields!
+    count: Int
+    max: FruitMinMaxFields!
+    min: FruitMinMaxFields!
+    stddevPop: FruitNumericFields!
+    stddevSamp: FruitNumericFields!
+    sum: FruitSumFields!
+    varPop: FruitNumericFields!
+    varSamp: FruitNumericFields!
+  }
+  
+  """GraphQL type"""
+  type FruitMinMaxFields {
+    name: String
+    sweetness: Int
+  }
+  
+  """GraphQL type"""
+  type FruitNumericFields {
+    sweetness: Float
+  }
+  
+  """GraphQL type"""
+  type FruitSumFields {
+    name: String
+    sweetness: Int
+  }
+  
+  """GraphQL type"""
   type FruitType {
     name: String!
     sweetness: Int!
   }
   
+  """GraphQL type"""
+  type FruitWithColorType {
+    color: ColorType!
+  }
+  
   type Query {
     fruit: FruitType!
+    fruitWithColor: FruitWithColorType!
   }
+  
+  scalar UUID
   '''
 # ---

--- a/tests/unit/schemas/include/include_explicit.py
+++ b/tests/unit/schemas/include/include_explicit.py
@@ -13,6 +13,12 @@ class FruitType:
     pass
 
 
+@strawchemy.type(Fruit, include=["color"])
+class FruitWithColorType:
+    pass
+
+
 @strawberry.type
 class Query:
     fruit: FruitType
+    fruit_with_color: FruitWithColorType


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

-

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Fix recursive include/exclude logic in DTO schema resolution to honor explicit includes and properly exclude non-init fields for write operations, update aggregation builder to use a full-include config for partial DTOs, and add tests covering explicit include scenarios.

Bug Fixes:
- Fix recursive field exclusion and inclusion logic when a relation is explicitly included
- Exclude fields not present in __init__ for write-purpose DTO schemas

Enhancements:
- Use include="all" in partial aggregate DTO configurations to ensure all aggregation fields are included

Tests:
- Add unit test and update snapshots for explicit include schema scenario