### PR TITLE
fix(schema): using override=True twice with the same name/model retai…

### DIFF
--- a/src/strawchemy/utils/registry.py
+++ b/src/strawchemy/utils/registry.py
@@ -262,7 +262,11 @@ class StrawberryRegistry:
         Returns:
             The type if it exists, otherwise None.
         """
-        if (existing := self.get(type_info.graphql_type, type_info.name, None)) and existing.override:
+        if (
+            not type_info.override
+            and (existing := self.get(type_info.graphql_type, type_info.name, None))
+            and existing.override
+        ):
             return self._type_map[existing]
         if not type_info.override and (existing := self._type_map.get(type_info)):
             return existing

--- a/tests/unit/mapping/test_schemas.py
+++ b/tests/unit/mapping/test_schemas.py
@@ -41,6 +41,34 @@ def test_type_instance(strawchemy: Strawchemy) -> None:
     assert user.name == "user"
 
 
+def test_override_same_name_does_not_leak_fields(strawchemy: Strawchemy) -> None:
+    """The last override wins when used with the same model/name pair.
+
+    A second `override=True` registration under the same GraphQL type name must
+    reflect its own (narrower) config, not inherit fields from the earlier
+    registration.
+    """
+    from tests.unit.models import Color, Fruit
+
+    @strawchemy.type(Fruit, name="FruitNode", include=["id"], override=True)
+    class FruitNode:
+        pass
+
+    @strawchemy.type(Color, name="ColorNode", include=["id", "name", "fruits"], override=True)
+    class ColorWide:
+        pass
+
+    @strawchemy.type(Color, name="ColorNode", include=["id"], override=True)
+    class ColorSlim:
+        pass
+
+    wide_fields = {f.name for f in ColorWide.__strawberry_definition__.fields}
+    slim_fields = {f.name for f in ColorSlim.__strawberry_definition__.fields}
+
+    assert wide_fields == {"fruits_aggregate", "fruits", "id", "name"}
+    assert slim_fields == {"id"}
+
+
 def test_type_instance_auto_as_str(strawchemy: Strawchemy) -> None:
     @strawchemy.type(User)
     class UserType:


### PR DESCRIPTION
…ns previous config

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

- Fixes #171 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type override resolution logic to properly isolate individual overrides and prevent unintended field inheritance from previously registered overrides that share the same type name.

* **Tests**
  * Added comprehensive test coverage to verify that type override isolation works correctly and prevents field data from leaking between different override registrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->